### PR TITLE
added sync-frontend-deps target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,13 @@ VECTOR_DB ?= milvus
 
 .DEFAULT_GOAL := help
 
-.PHONY: init-env build-frontend build-backend build-tests build-all test api-test newman-test all-test run-app run-backend run-frontend run-services stop-containers clean create-volumes logs info help
+.PHONY: init-env sync-frontend-deps build-frontend build-backend build-tests build-all test api-test newman-test all-test run-app run-backend run-frontend run-services stop-containers clean create-volumes logs info help
+
+# Add this before the build targets
+sync-frontend-deps:
+	@echo "Syncing frontend dependencies..."
+	@cd webui && npm install
+	@echo "Frontend dependencies synced."
 
 # Init
 init-env:


### PR DESCRIPTION
Modified Makefile:

Added the following lines:
# Add this before the build targets
sync-frontend-deps:
	@echo "Syncing frontend dependencies..."
	@cd webui && npm install
	@echo "Frontend dependencies synced."
	
Modified the .PHONY line to include the above target:
.PHONY: init-env sync-frontend-deps build-frontend build-backend build-tests build-all test api-test newman-test all-test run-app run-backend run-frontend run-services stop-containers clean create-volumes logs info help
