### PR TITLE
Cleanup to support deployment on OCP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ sync-frontend-deps:
 
 # Build
 build-frontend: sync-frontend-deps
-	$(CONTAINER_CLI) build -t ${PROJECT_NAME}/frontend:${PROJECT_VERSION} -f ./webui/Dockerfile.frontend --build-arg REACT_APP_API_URL=${REACT_APP_API_URL} --build-arg REACT_APP_OIDC_CLIENT_ID=${IBM_CLIENT_ID}  ./webui
+	$(CONTAINER_CLI) build -t ${PROJECT_NAME}/frontend:${PROJECT_VERSION} -f ./webui/Dockerfile.frontend ./webui
 
 build-backend:
 	$(CONTAINER_CLI) build -t ${PROJECT_NAME}/backend:${PROJECT_VERSION} -f ./backend/Dockerfile.backend ./backend
@@ -153,7 +153,7 @@ clean: stop-containers
 # Service / reusable targets
 create-volumes:
 	@echo "Creating volume directories with correct permissions..."
-	@mkdir -p ./volumes/postgres ./volumes/etcd ./volumes/minio ./volumes/milvus
+	@mkdir -p ./volumes/postgres ./volumes/etcd ./volumes/minio ./volumes/milvus ./volumes/backend
 	@chmod -R 777 ./volumes
 	@echo "Volume directories created and permissions set."
 

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -48,7 +48,7 @@ class Settings(BaseSettings):
     log_level: Optional[str] = None
 
     # File storage path
-    file_storage_path: str = tempfile.gettempdir()
+    file_storage_path: str = Field(default=tempfile.gettempdir(), env='FILE_STORAGE_PATH')
 
     # ChromaDB credentials
     chromadb_host: Optional[str] = None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - COLLECTIONDB_HOST=postgres
     env_file:
       - .env
+    volumes:
+      - backend_data:/mnt/data
     healthcheck:
       test: ["CMD", "python", "healthcheck.py"]
       interval: 30s
@@ -36,9 +38,6 @@ services:
       - "3000:8080"
     depends_on:
       - backend
-    environment:
-      - REACT_APP_API_URL=/api
-      - REACT_APP_OIDC_CLIENT_ID=${IBM_CLIENT_ID}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080"]
       interval: 30s
@@ -76,3 +75,6 @@ services:
       - IBM_CLIENT_SECRET=${IBM_CLIENT_SECRET}
     env_file:
       - .env
+
+volumes:
+  backend_data:

--- a/webui/Dockerfile.frontend
+++ b/webui/Dockerfile.frontend
@@ -1,12 +1,7 @@
 # Use a smaller base image for Node.js
 FROM node:18-alpine AS builder
 
-ARG REACT_APP_API_URL=/api
-ARG REACT_APP_OIDC_CLIENT_ID
-
-ENV REACT_APP_API_URL=$REACT_APP_API_URL \
-    REACT_APP_OIDC_CLIENT_ID=$REACT_APP_OIDC_CLIENT_ID \
-    NODE_ENV=production 
+ENV NODE_ENV=production 
 # Set the working directory
 WORKDIR /app
 

--- a/webui/src/config/config.js
+++ b/webui/src/config/config.js
@@ -1,10 +1,8 @@
 const config = {
-    apiUrl: process.env.REACT_APP_API_URL || '/api',
-    oidcClientId: process.env.REACT_APP_OIDC_CLIENT_ID,
+    apiUrl: '/api'
 };
 
 console.log("Config initialized:", config);
-console.log("REACT_APP_API_URL:", process.env.REACT_APP_API_URL);
 console.log("Window location origin:", window.location.origin);
 console.log("Final apiUrl:", config.apiUrl);
 
@@ -30,7 +28,6 @@ const getFullApiUrl = (route) => {
 };
 
 const authConfig = {
-    client_id: config.oidcClientId,
     redirect_uri: `${window.location.origin}/api/auth/callback`,
     response_type: "code",
     scope: "openid profile email",


### PR DESCRIPTION
- Made file storage path configurable, so files persist in containerized deployment. Previously tempfile.gettempdir() was the only option. Path is managed by env property FILE_STORAGE_PATH, volume will be mounted to that path
- Cleaned GUI from redundant build params/configs (OAUTH CLIENT_ID and API path)