### PR TITLE
changes to show document name in search and group search results 

### DIFF
--- a/backend/rag_solution/schemas/search_schema.py
+++ b/backend/rag_solution/schemas/search_schema.py
@@ -11,6 +11,7 @@ class DocumentMetadata(BaseModel):
     title: Optional[str] = None
     page_number: Optional[int] = None
     total_pages: Optional[int] = None
+    document_name: Optional[str] = None 
 
 class SourceDocument(BaseModel):
     text: str

--- a/backend/rag_solution/services/search_service.py
+++ b/backend/rag_solution/services/search_service.py
@@ -121,7 +121,8 @@ class SearchService:
                             url=chunk.metadata.url if chunk.metadata else None,
                             created_at=chunk.metadata.created_at if chunk.metadata else None,
                             author=chunk.metadata.author if chunk.metadata else None,
-                            page_number=chunk.metadata.page_number if chunk.metadata else None
+                            page_number=chunk.metadata.page_number if chunk.metadata else None,
+                            document_name=chunk.metadata.document_name if chunk.metadata else None
                         )
                         
                         source_documents.append(SourceDocument(

--- a/backend/vectordbs/data_types.py
+++ b/backend/vectordbs/data_types.py
@@ -74,6 +74,7 @@ class DocumentChunkMetadata:
     content_type: Optional[str] = None
     table_index: Optional[int] = None
     image_index: Optional[int] = None
+    document_name: Optional[str] = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> DocumentChunkMetadata:

--- a/backend/vectordbs/milvus_store.py
+++ b/backend/vectordbs/milvus_store.py
@@ -43,6 +43,7 @@ SCHEMA = [
     FieldSchema(name="created_at", dtype=DataType.VARCHAR, max_length=50),
     FieldSchema(name="author", dtype=DataType.VARCHAR, max_length=100),
     FieldSchema(name="page_number", dtype=DataType.INT64), # Temporary fix
+    FieldSchema(name="document_name", dtype=DataType.VARCHAR, max_length=65535),
 ]
 
 
@@ -170,6 +171,7 @@ class MilvusStore(VectorStore):
                             "embedding": chunk.vectors,
                             "text": chunk.text,
                             "chunk_id": chunk.chunk_id,
+                            "document_name": document.name,  # Add document name
                             "source_id": chunk.metadata.source_id if chunk.metadata else "",
                             "source": chunk.metadata.source.value if chunk.metadata else "",
                             "url": chunk.metadata.url if chunk.metadata else "",
@@ -229,6 +231,7 @@ class MilvusStore(VectorStore):
                     "created_at",
                     "author",
                     "page_number", # Temporary fix
+                    "document_name", 
                 ],
                 limit=number_of_results,  # Milvus API uses limit, but we maintain our consistent interface
             )
@@ -346,6 +349,7 @@ class MilvusStore(VectorStore):
                     "created_at",
                     "author",
                     "page_number",
+                    "document_name",
                 ],
             )
             return self._process_search_results(result)
@@ -404,6 +408,7 @@ class MilvusStore(VectorStore):
                     vectors=hit.entity.get("embedding"),
                     metadata=DocumentChunkMetadata(
                         source=Source(hit.entity.get("source")) if hit.entity.get("source") else Source.OTHER,
+                        document_name=hit.entity.get("document_name") if hit.entity.get("document_name") else "Untitled Document",
                         source_id=hit.entity.get("source_id"),
                         url=hit.entity.get("url"),
                         created_at=hit.entity.get("created_at"),

--- a/webui/src/components/common/SearchInterface.css
+++ b/webui/src/components/common/SearchInterface.css
@@ -82,3 +82,38 @@ mark {
     grid-template-columns: 1fr;
   }
 }
+
+.source-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.5rem;
+}
+
+.source-header svg {
+  flex-shrink: 0;
+  color: #0f62fe;
+}
+
+.source-header span {
+  flex: 1;
+  font-weight: 600;
+}
+
+.source-chunk {
+  margin-bottom: 1rem;
+  border-left: 3px solid #0f62fe;
+  padding-left: 1rem;
+}
+
+.chunk-score {
+  color: #525252;
+  margin-top: 0.5rem;
+}
+
+.source-metadata {
+  margin-bottom: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}


### PR DESCRIPTION
The search page now looks as follows:

<img width="1656" alt="image" src="https://github.com/user-attachments/assets/057762b4-c237-4c29-846c-fa90fd87f0d5" />
<img width="1633" alt="image" src="https://github.com/user-attachments/assets/490b396d-24c9-4447-b938-da19dc0c9000" />
