### PR TITLE
Refactored LLM providers to use configuration services for improved maintainability

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -46,6 +46,12 @@ class LegacySettings(BaseSettings):
     repetition_penalty: float = Field(default=1.1, env='REPETITION_PENALTY')
     runtime_eval: bool = Field(default=False, env='RUNTIME_EVAL')
 
+    # WatsonX.ai settings
+    wx_project_id: Optional[str] = Field(default=None, env='WATSONX_INSTANCE_ID')
+    wx_api_key: Optional[str] = Field(default=None, env='WATSONX_APIKEY')
+    wx_url: Optional[str] = Field(default=None, env='WATSONX_URL')
+    llm_concurrency: int = Field(default=10)
+
     # Query Rewriting settings
     use_simple_rewriter: bool = Field(default=True, env='USE_SIMPLE_REWRITER')
     use_hyponym_rewriter: bool = Field(default=False, env='USE_HYPONYM_REWRITER')
@@ -83,6 +89,11 @@ class LegacySettings(BaseSettings):
     chromadb_host: Optional[str] = Field(default="localhost", env='CHROMADB_HOST')
     chromadb_port: Optional[int] = Field(default=8000, env='CHROMADB_PORT')
     
+    # Milvus settings
+    milvus_host: str = Field(default="milvus-standalone", env='MILVUS_HOST')
+    milvus_port: int = Field(default=19530, env='MILVUS_PORT')
+    milvus_user: str = Field(default="root", env='MILVUS_USER')
+    milvus_password: str = Field(default="milvus", env='MILVUS_PASSWORD')
     milvus_index_params: Optional[str] = Field(default=None, env='MILVUS_INDEX_PARAMS')
     milvus_search_params: Optional[str] = Field(default=None, env='MILVUS_SEARCH_PARAMS')
 
@@ -104,6 +115,13 @@ class LegacySettings(BaseSettings):
     weaviate_password: Optional[str] = Field(default=None, env='WEAVIATE_PASSWORD')
     weaviate_index: Optional[str] = Field(default="default", env='WEAVIATE_INDEX')
     weaviate_scopes: Optional[str] = Field(default=None, env='WEAVIATE_SCOPES')
+
+    # Collection database settings
+    collectiondb_user: str = Field(default="rag_modulo_user", env='COLLECTIONDB_USER')
+    collectiondb_pass: str = Field(default="rag_modulo_password", env='COLLECTIONDB_PASS')
+    collectiondb_host: str = Field(default="localhost", env='COLLECTIONDB_HOST')
+    collectiondb_port: int = Field(default=5432, env='COLLECTIONDB_PORT')
+    collectiondb_name: str = Field(default="rag_modulo", env='COLLECTIONDB_NAME')
 
     # RBAC settings
     rbac_mapping: Dict[str, Dict[str, List[str]]] = {
@@ -136,21 +154,10 @@ class Settings(BaseSettings):
         validate_default=True
     )
 
-    # WatsonX.ai credentials
-    wx_project_id: Optional[str] = Field(default=None, env='WATSONX_INSTANCE_ID')
-    wx_api_key: Optional[str] = Field(default=None, env='WATSONX_APIKEY')
-    wx_url: Optional[str] = Field(default=None, env='WATSONX_URL')
-    llm_concurrency: int = Field(default=10)
-
     # Core data settings
     data_dir: Optional[str] = None
     vector_db: str = Field(default="milvus", env='VECTOR_DB')
 
-    # Default vector DB connection (Milvus)
-    milvus_host: str = Field(default="milvus-standalone", env='MILVUS_HOST')
-    milvus_port: int = Field(default=19530, env='MILVUS_PORT')
-    milvus_user: str = Field(default="root", env='MILVUS_USER')
-    milvus_password: str = Field(default="milvus", env='MILVUS_PASSWORD')
 
     # Frontend settings
     react_app_api_url: str = Field(default="/api", env='REACT_APP_API_URL')
@@ -166,12 +173,6 @@ class Settings(BaseSettings):
     oidc_userinfo_endpoint: Optional[str] = Field(default=None, env='OIDC_USERINFO_ENDPOINT')
     oidc_introspection_endpoint: Optional[str] = Field(default=None, env='OIDC_INTROSPECTION_ENDPOINT')
 
-    # Collection database settings
-    collectiondb_user: str = Field(default="rag_modulo_user", env='COLLECTIONDB_USER')
-    collectiondb_pass: str = Field(default="rag_modulo_password", env='COLLECTIONDB_PASS')
-    collectiondb_host: str = Field(default="localhost", env='COLLECTIONDB_HOST')
-    collectiondb_port: int = Field(default=5432, env='COLLECTIONDB_PORT')
-    collectiondb_name: str = Field(default="rag_modulo", env='COLLECTIONDB_NAME')
 
     # Project settings
     project_name: str = Field(default="rag_modulo", env='PROJECT_NAME')

--- a/backend/core/custom_exceptions.py
+++ b/backend/core/custom_exceptions.py
@@ -342,6 +342,45 @@ class InvalidPromptTemplateError(ValidationError):
             }
         )
 
+class LLMProviderError(BaseCustomException):
+    """Exception raised for errors during LLM provider operations.
+    
+    This exception handles errors that occur during:
+    - Provider initialization
+    - Text generation
+    - Streaming generation
+    - Embedding generation
+    - Client operations
+    """
+    
+    def __init__(
+        self,
+        provider: str,
+        error_type: str,
+        message: str,
+        operation: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Initialize LLM provider error.
+        
+        Args:
+            provider: Name of the LLM provider (e.g., watsonx, openai, anthropic)
+            error_type: Type of error (e.g., initialization, authentication, rate_limit)
+            message: Error message
+            operation: Optional operation that failed (e.g., generate, embed)
+            details: Additional error details
+        """
+        super().__init__(
+            message,
+            status_code=500,
+            details={
+                "provider": provider,
+                "error_type": error_type,
+                **({"operation": operation} if operation else {}),
+                **(details or {})
+            }
+        )
+
 class ProviderConfigError(BaseCustomException):
     """Exception raised for errors related to provider configuration."""
     

--- a/backend/rag_solution/docs/provider_configuration.md
+++ b/backend/rag_solution/docs/provider_configuration.md
@@ -4,6 +4,51 @@
 
 The provider configuration system enables dynamic registration and management of LLM providers and their models. It provides a flexible way to configure and manage different LLM providers with their specific parameters, active status, and verification tracking.
 
+## Configuration Types
+
+### 1. Provider Configuration
+Managed by provider_config_service, these are essential configurations required for provider initialization:
+
+```python
+# Example Provider Configuration
+watsonx_config = provider_config_service.get_provider_config("watsonx")
+if not watsonx_config:
+    raise LLMProviderError(
+        provider="watsonx",
+        error_type=PROVIDER_ERROR_TYPES["CONFIG_INVALID"],
+        message="No configuration found for WatsonX provider"
+    )
+```
+
+Provider-specific requirements:
+- WatsonX: api_key, api_url, project_id
+- OpenAI: api_key, org_id
+- Anthropic: api_key
+
+### 2. Runtime Configuration
+Managed through ProviderConfig, these settings control runtime behavior:
+
+```python
+runtime_config = ProviderConfig(
+    concurrency_limit=5,
+    timeout=60,
+    batch_size=20,
+    stream=True,
+    rate_limit=20,
+    retry_attempts=3,
+    retry_delay=1.0
+)
+```
+
+Settings include:
+- concurrency_limit: Maximum concurrent requests
+- timeout: Request timeout in seconds
+- batch_size: Size of batches for bulk operations
+- stream: Whether to use streaming mode
+- rate_limit: Maximum requests per second
+- retry_attempts: Number of retry attempts
+- retry_delay: Delay between retries in seconds
+
 ## Architecture
 
 ### Configuration Storage Hierarchy
@@ -34,7 +79,6 @@ ProviderModelConfig (SQLAlchemy Model)
    - `ProviderModelConfigCreate`: Creation schema
    - `ProviderModelConfigUpdate`: Partial update support
    - `ProviderModelConfigResponse`: API response format
-   - `ProviderRegistryResponse`: Registry listing format
 
 3. **Repository**
    - CRUD operations
@@ -48,287 +92,180 @@ ProviderModelConfig (SQLAlchemy Model)
    - Model verification
    - Parameter management
 
-## Configuration
+## Error Handling
 
-### Database Setup
+The system provides standardized error types for consistent error handling across providers:
 
-The provider configuration system uses PostgreSQL for storage. The SQLAlchemy model automatically creates the required table:
+### Error Categories
 
-```sql
-CREATE TABLE provider_model_configs (
-    id SERIAL PRIMARY KEY,
-    model_id VARCHAR(255) NOT NULL,
-    provider_name VARCHAR(255) NOT NULL,
-    is_active BOOLEAN NOT NULL DEFAULT TRUE,
-    last_verified TIMESTAMP WITH TIME ZONE,
-    parameters_id INTEGER NOT NULL REFERENCES llm_parameters(id) ON DELETE CASCADE,
-    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    UNIQUE(provider_name, model_id)
-);
+1. Initialization Errors
+```python
+PROVIDER_ERROR_TYPES = {
+    "INIT_FAILED": "initialization_failed",
+    "AUTH_FAILED": "authentication_failed",
+    "CONFIG_INVALID": "configuration_invalid"
+}
 ```
 
-### System Initialization
-
-1. **First-Time Setup**
-   - Database tables are created if they don't exist
-   - Service validates provider configurations
-   - Links with existing LLM parameters
-
-2. **Provider Registration**
-   - Providers are registered with their models
-   - LLM parameters are created and linked
-   - Active status is set
-   - Initial verification is performed
-
-### Provider Management Flow
-
-```mermaid
-graph TD
-    A[Start] --> B{Register Provider}
-    B --> C[Create LLM Parameters]
-    C --> D[Create Provider Config]
-    D --> E[Verify Provider]
-    E --> F[Activate Provider]
-    F --> G[End]
+2. Runtime Errors
+```python
+PROVIDER_ERROR_TYPES = {
+    "RATE_LIMIT": "rate_limit_exceeded",
+    "TIMEOUT": "request_timeout",
+    "API_ERROR": "api_error"
+}
 ```
 
-## Usage
+3. Generation Errors
+```python
+PROVIDER_ERROR_TYPES = {
+    "PROMPT_ERROR": "prompt_preparation_failed",
+    "TEMPLATE_ERROR": "template_formatting_failed",
+    "PARAM_ERROR": "invalid_parameters"
+}
+```
 
-### Registering Providers
+4. Resource Errors
+```python
+PROVIDER_ERROR_TYPES = {
+    "MODEL_ERROR": "model_not_available",
+    "RESOURCE_ERROR": "resource_exhausted"
+}
+```
+
+5. Response Errors
+```python
+PROVIDER_ERROR_TYPES = {
+    "RESPONSE_ERROR": "invalid_response",
+    "PARSING_ERROR": "response_parsing_failed"
+}
+```
+
+## Integration Examples
+
+### Provider Implementation
 
 ```python
-# Create LLM parameters for the model
-parameters = LLMParametersCreate(
-    name="watsonx_granite_params",
-    description="Parameters for Watsonx Granite model",
-    max_new_tokens=100,
-    temperature=0.7,
-    top_k=50,
-    top_p=1.0
-)
-
-# Create prompt template
-template = PromptTemplateCreate(
-    name="watsonx_default",
-    provider="watsonx",
-    description="Default template for Watsonx",
-    system_prompt="You are a helpful AI assistant",
-    context_prefix="Context:",
-    query_prefix="Question:",
-    answer_prefix="Answer:"
-)
-
-# Register provider with parameters and template
-config = provider_config_service.register_provider_model(
-    provider="watsonx",
-    model_id="granite-13b",
-    parameters=parameters,
-    prompt_template=template
-)
-```
-
-### Managing Providers
-
-```python
-# Get provider configuration
-config = service.get_provider_model("watsonx", "granite-13b")
-
-# Update provider status
-service.update_provider_model(
-    provider="watsonx",
-    model_id="granite-13b",
-    updates={"is_active": False}
-)
-
-# Verify provider
-service.verify_provider_model("watsonx", "granite-13b")
-
-# List providers
-registry = service.list_providers(active_only=True)
-```
-
-## Integration
-
-### Generator Integration
-
-The provider configuration system integrates with the generation system:
-
-```python
-class Generator:
-    def __init__(self, provider_config_service: ProviderConfigService):
-        self._config_service = provider_config_service
+class WatsonXProvider(LLMProvider):
+    def __init__(self, provider_config_service: ProviderConfigService) -> None:
+        """Initialize WatsonX provider.
         
-    def generate(self, provider: str, model_id: str, prompt: str):
-        # Get provider configuration
-        config = self._config_service.get_provider_model(provider, model_id)
-        if not config or not config.is_active:
-            raise ProviderConfigError(...)
-            
-        # Use configuration parameters
-        params = config.parameters
-        # Generate response using configured parameters
+        Args:
+            provider_config_service: Service for provider configuration
+        """
+        # Initialize base attributes
+        self.provider_config_service = provider_config_service
+        self.client = None
+        self.embeddings_client = None
+        self._model_cache = {}
+        
+        # Get and validate configuration
+        self._provider_config = self.provider_config_service.get_provider_config("watsonx")
+        if not self._provider_config:
+            raise LLMProviderError(
+                provider="watsonx",
+                error_type=PROVIDER_ERROR_TYPES["CONFIG_INVALID"],
+                message="No configuration found for WatsonX provider"
+            )
+
+        # Initialize base class
+        super().__init__()
+
+    def initialize_client(self) -> None:
+        """Initialize WatsonX client."""
+        try:
+            self.client = APIClient(
+                project_id=self._provider_config.project_id,
+                credentials=Credentials(
+                    api_key=self._provider_config.api_key,
+                    url=self._provider_config.api_url
+                )
+            )
+        except Exception as e:
+            raise LLMProviderError(
+                provider="watsonx",
+                error_type=PROVIDER_ERROR_TYPES["INIT_FAILED"],
+                message=f"Failed to initialize client: {str(e)}"
+            )
 ```
 
-### Factory Integration
+### Factory Implementation
 
 ```python
-class ProviderFactory:
-    def __init__(self, provider_config_service: ProviderConfigService):
-        self._config_service = provider_config_service
+class LLMProviderFactory:
+    """Factory for creating and managing LLM providers with logging."""
+    
+    _providers: Dict[str, Type[LLMProvider]] = {
+        "watsonx": WatsonXProvider,
+        "openai": OpenAIProvider,
+        "anthropic": AnthropicProvider
+    }
+    _instances: Dict[str, LLMProvider] = {}
+
+    def __init__(self, db: Session) -> None:
+        """Initialize factory with database session."""
+        self._provider_config_service = ProviderConfigService(db)
+
+    def get_provider(self, provider_type: str) -> LLMProvider:
+        """Get or create a provider instance."""
+        provider_type = provider_type.lower()
         
-    def create_provider(self, provider: str, model_id: str):
-        config = self._config_service.get_provider_model(provider, model_id)
-        if not config:
-            raise ProviderConfigError(...)
-            
-        if provider == "watsonx":
-            return WatsonxProvider(config)
-        elif provider == "openai":
-            return OpenAIProvider(config)
+        if provider_type not in self._providers:
+            raise LLMProviderError(
+                provider=provider_type,
+                error_type="unknown_provider",
+                message=f"Unknown provider type: {provider_type}"
+            )
+
+        # Create new instance if needed
+        if provider_type not in self._instances:
+            self._instances[provider_type] = self._providers[provider_type](
+                provider_config_service=self._provider_config_service
+            )
+
+        return self._instances[provider_type]
 ```
 
 ## Best Practices
 
-1. **Provider Registration**
-   - Register providers with appropriate parameters
-   - Validate model IDs and provider names
-   - Set meaningful parameter names
+1. **Configuration Management**
+   - Use provider_config_service for provider settings
+   - Use ProviderConfig for runtime settings
+   - Validate configurations at startup
 
-2. **Status Management**
-   - Regularly verify provider availability
-   - Update status based on verification
-   - Monitor active providers
+2. **Error Handling**
+   - Use standardized error types from PROVIDER_ERROR_TYPES
+   - Include provider name in errors
+   - Log errors with context
 
-3. **Parameter Management**
-   - Use provider-specific parameter ranges
-   - Document parameter choices
-   - Test parameter configurations
+3. **Provider Implementation**
+   - Initialize configuration in __init__
+   - Handle client initialization separately
+   - Clean up resources in close()
 
-## Error Handling
-
-The system provides specific exceptions:
-- `ProviderConfigError`
-  * Registration errors
-  * Verification failures
-  * Parameter validation errors
-  * Status update issues
-
-## Security Considerations
-
-### Access Control
-- Implement role-based access for provider management
-- Restrict provider registration capabilities
-- Control parameter modifications
-- Audit provider configuration changes
-
-### Verification
-- Regular provider verification
-- Automated status updates
-- Connection testing
-- Parameter validation
+4. **Testing**
+   - Test provider validation
+   - Test error handling
+   - Mock external services
 
 ## Future Improvements
 
-1. **Provider Versioning**
-   - Track provider versions
-   - Version-specific parameters
-   - Migration support
+1. **Configuration Management**
+   - Dynamic runtime configuration updates
+   - Configuration validation rules
+   - Configuration versioning
 
-2. **Health Monitoring**
-   - Provider health checks
-   - Usage statistics
-   - Performance metrics
+2. **Error Handling**
+   - Custom error recovery strategies
+   - Error aggregation and analysis
+   - Automatic error recovery
 
-3. **Parameter Templates**
-   - Pre-configured parameter sets
-   - Use case specific configurations
-   - Parameter inheritance
+3. **Monitoring**
+   - Configuration usage metrics
+   - Error rate tracking
+   - Performance monitoring
 
-4. **Provider Discovery**
-   - Automatic provider detection
-   - Capability discovery
-   - Feature detection
-
-## Usage Examples
-
-### Basic Provider Setup
-
-```python
-# Register IBM Watsonx provider
-watsonx_params = LLMParametersCreate(
-    name="watsonx_default",
-    description="Default Watsonx parameters",
-    max_new_tokens=100,
-    temperature=0.7,
-    top_k=50,
-    top_p=1.0
-)
-
-watsonx_template = PromptTemplateCreate(
-    name="watsonx_default",
-    provider="watsonx",
-    description="Default Watsonx template",
-    system_prompt="You are a helpful AI assistant powered by IBM Watsonx",
-    context_prefix="Context:",
-    query_prefix="Question:",
-    answer_prefix="Answer:"
-)
-
-watsonx_config = provider_config_service.register_provider_model(
-    provider="watsonx",
-    model_id="granite-13b",
-    parameters=watsonx_params,
-    prompt_template=watsonx_template
-)
-
-# Register OpenAI provider
-openai_params = LLMParametersCreate(
-    name="openai_default",
-    description="Default OpenAI parameters",
-    max_new_tokens=150,
-    temperature=0.9,
-    top_k=50,
-    top_p=1.0
-)
-
-openai_template = PromptTemplateCreate(
-    name="openai_default",
-    provider="openai",
-    description="Default OpenAI template",
-    system_prompt="You are a helpful AI assistant powered by OpenAI",
-    context_prefix="Context:",
-    query_prefix="Question:",
-    answer_prefix="Answer:"
-)
-
-openai_config = provider_config_service.register_provider_model(
-    provider="openai",
-    model_id="gpt-4",
-    parameters=openai_params,
-    prompt_template=openai_template
-)
-```
-
-### Advanced Usage
-
-```python
-# Get active providers
-registry = provider_config_service.list_providers(active_only=True)
-
-# Update provider parameters
-provider_config_service.update_provider_model(
-    provider="watsonx",
-    model_id="granite-13b",
-    updates={
-        "parameters_id": new_params.id,
-        "is_active": True
-    }
-)
-
-# Verify all providers
-for provider in registry.providers:
-    provider_config_service.verify_provider_model(
-        provider.provider_name,
-        provider.model_id
-    )
+4. **Security**
+   - Configuration encryption
+   - Access control
+   - Audit logging

--- a/backend/rag_solution/generation/providers/factory.py
+++ b/backend/rag_solution/generation/providers/factory.py
@@ -1,12 +1,14 @@
 """Factory for LLM providers with logging."""
 
 from typing import Dict, Type
+from sqlalchemy.orm import Session
 from core.logging_utils import get_logger
 from .base import LLMProvider
 from .watsonx import WatsonXProvider
 from .openai import OpenAIProvider
 from .anthropic import AnthropicProvider
 from core.custom_exceptions import LLMProviderError
+from rag_solution.services.provider_config_service import ProviderConfigService
 
 logger = get_logger("llm.providers.factory")
 
@@ -19,6 +21,7 @@ class LLMProviderFactory:
     Attributes:
         _providers: Mapping of provider names to their implementation classes
         _instances: Cache of provider instances
+        _provider_config_service: Service for provider configuration
     """
     
     _providers: Dict[str, Type[LLMProvider]] = {
@@ -28,8 +31,15 @@ class LLMProviderFactory:
     }
     _instances: Dict[str, LLMProvider] = {}
 
-    @classmethod
-    def get_provider(cls, provider_type: str) -> LLMProvider:
+    def __init__(self, db: Session) -> None:
+        """Initialize factory with database session.
+        
+        Args:
+            db: SQLAlchemy database session
+        """
+        self._provider_config_service = ProviderConfigService(db)
+
+    def get_provider(self, provider_type: str) -> LLMProvider:
         """Get or create a provider instance with logging.
         
         Args:
@@ -39,50 +49,67 @@ class LLMProviderFactory:
             LLMProvider: Instance of the requested provider
             
         Raises:
-            LLMProviderError: If provider type is unknown
+            LLMProviderError: If provider type is unknown or configuration invalid
         """
         provider_type = provider_type.lower()
         
-        if provider_type not in cls._providers:
+        if provider_type not in self._providers:
             logger.error(f"Unknown provider type requested: {provider_type}")
-            raise LLMProviderError(f"Unknown provider type: {provider_type}")
+            raise LLMProviderError(
+                provider=provider_type,
+                error_type="unknown_provider",
+                message=f"Unknown provider type: {provider_type}"
+            )
 
         # Check if we have a valid instance
-        if (provider_type not in cls._instances or 
-            cls._instances[provider_type].client is None):
+        if (provider_type not in self._instances or 
+            self._instances[provider_type].client is None):
             
             # If instance exists but client is None, clean it up first
-            if provider_type in cls._instances:
+            if provider_type in self._instances:
                 logger.warning(f"Found stale {provider_type} provider instance, reinitializing")
                 try:
-                    cls._instances[provider_type].close()
+                    self._instances[provider_type].close()
                 except Exception as e:
                     logger.error(f"Error closing stale provider: {str(e)}")
-                cls._instances.pop(provider_type)
+                self._instances.pop(provider_type)
 
-            # Create new instance
+            # Create new instance with configuration
             logger.info(f"Creating new instance of {provider_type} provider")
-            cls._instances[provider_type] = cls._providers[provider_type]()
+            try:
+                self._instances[provider_type] = self._providers[provider_type](
+                    provider_config_service=self._provider_config_service
+                )
+            except Exception as e:
+                logger.error(f"Failed to initialize {provider_type} provider: {str(e)}")
+                raise LLMProviderError(
+                    provider=provider_type,
+                    error_type="initialization_error",
+                    message=f"Failed to initialize provider: {str(e)}"
+                )
 
             # Verify initialization
-            if cls._instances[provider_type].client is None:
+            if self._instances[provider_type].client is None:
                 logger.error(f"Failed to initialize {provider_type} provider client")
-                raise LLMProviderError(f"Failed to initialize {provider_type} provider")
+                raise LLMProviderError(
+                    provider=provider_type,
+                    error_type="initialization_error",
+                    message=f"Failed to initialize provider client"
+                )
 
-        return cls._instances[provider_type]
+        return self._instances[provider_type]
 
-    @classmethod
-    async def close_all(cls) -> None:
+    async def close_all(self) -> None:
         """Clean up all provider instances.
         
         Closes all active provider instances and clears the instance cache.
         Logs any errors that occur during cleanup.
         """
         logger.info("Closing all provider instances")
-        for provider_type, provider in cls._instances.items():
+        for provider_type, provider in self._instances.items():
             try:
                 provider.close()  # Remove the await since close() is sync
                 logger.debug(f"Closed {provider_type} provider")
             except Exception as e:
                 logger.error(f"Error closing {provider_type} provider: {str(e)}")
-        cls._instances.clear()
+        self._instances.clear()

--- a/backend/rag_solution/generation/providers/watsonx.py
+++ b/backend/rag_solution/generation/providers/watsonx.py
@@ -1,125 +1,163 @@
-#backend/rag_solution/generation/providers/watsonx.py
+"""WatsonX provider implementation using IBM watsonx.ai API."""
+
 from typing import Dict, List, Optional, Union, Generator, Any
 import asyncio
 from core.logging_utils import get_logger
-from functools import lru_cache
 
-from dotenv import load_dotenv
 from ibm_watsonx_ai import APIClient, Credentials
 from ibm_watsonx_ai.metanames import EmbedTextParamsMetaNames as EmbedParams
 from ibm_watsonx_ai.metanames import GenTextParamsMetaNames as GenParams
 from ibm_watsonx_ai.foundation_models import ModelInference, Embeddings as wx_Embeddings
 
-from .base import LLMProvider, ProviderConfig
-from core.config import settings
-from vectordbs.data_types import  EmbeddingsList
+from .base import LLMProvider, ProviderConfig, PROVIDER_ERROR_TYPES
+from vectordbs.data_types import EmbeddingsList
 from core.custom_exceptions import LLMProviderError
-from rag_solution.schemas.model_parameters_schema import ModelParametersInput
-from rag_solution.schemas.prompt_template_schema import BasePromptTemplate
+from rag_solution.schemas.llm_parameters_schema import LLMParametersBase
+from rag_solution.schemas.prompt_template_schema import PromptTemplateBase
+from rag_solution.services.provider_config_service import ProviderConfigService
 
 logger = get_logger("llm.providers.watsonx")
-
-load_dotenv(override=True)
 
 class WatsonXProvider(LLMProvider):
     """WatsonX provider implementation using IBM watsonx.ai API."""
 
-    def __init__(self) -> None:
-        """Initialize WatsonX provider with API client and models."""
-        super().__init__()
-        self.embedding_model: str = settings.embedding_model
-    
-    def initialize_client(self) -> None:
-        """Initialize WatsonX client and related resources."""
+    def __init__(self, provider_config_service: ProviderConfigService) -> None:
+        """Initialize WatsonX provider.
+        
+        Args:
+            provider_config_service: Service for provider configuration
+        """
         try:
-            self.client = APIClient(
-                project_id=settings.wx_project_id,
-                credentials=Credentials(
-                    api_key=settings.wx_api_key,
-                    url=settings.wx_url
-                )
-            )
+            # Initialize base attributes
+            self.provider_config_service = provider_config_service
+            self.client = None
+            self.embeddings_client = None
             self._model_cache = {}
             
-            # Initialize embeddings client
-            self._get_embeddings_client()
-        except Exception as e:
-            logger.error(f"Failed to initialize WatsonX client: {str(e)}")
-            raise LLMProviderError(f"Initialization failed: {str(e)}")
-
-    def _get_embeddings_client(self) -> wx_Embeddings:
-        """Get or create embeddings client instance."""
-        try:
-            if not hasattr(self, 'embeddings_client') or self.embeddings_client is None:
-                embed_params = {
-                    EmbedParams.RETURN_OPTIONS: {"input_text": True},
-                }
-                self.embeddings_client = wx_Embeddings(
-                    persistent_connection=True,
-                    model_id=settings.embedding_model,
-                    params=embed_params,
-                    project_id=settings.wx_project_id,
-                    credentials=Credentials(
-                        api_key=settings.wx_api_key,
-                        url=settings.wx_url
-                    )
+            # Get and validate configuration
+            self._provider_config = self.provider_config_service.get_provider_config("watsonx")
+            if not self._provider_config:
+                raise LLMProviderError(
+                    provider="watsonx",
+                    error_type=PROVIDER_ERROR_TYPES["CONFIG_INVALID"],
+                    message="No configuration found for WatsonX provider"
                 )
-            return self.embeddings_client
-        except Exception as e:
-            raise LLMProviderError(f"Failed to get embeddings client: {str(e)}")
 
-    def _get_model(self, model_id: str = settings.rag_llm) -> ModelInference:
+            # Validate required fields
+            if not self._provider_config.api_url:
+                raise LLMProviderError(
+                    provider="watsonx",
+                    error_type=PROVIDER_ERROR_TYPES["CONFIG_INVALID"],
+                    message="api_url is required for WatsonX provider"
+                )
+            if not self._provider_config.project_id:
+                raise LLMProviderError(
+                    provider="watsonx",
+                    error_type=PROVIDER_ERROR_TYPES["CONFIG_INVALID"],
+                    message="project_id is required for WatsonX provider"
+                )
+            
+            # Initialize base class and client
+            super().__init__()
+            
+        except LLMProviderError:
+            raise
+        except Exception as e:
+            raise LLMProviderError(
+                provider="watsonx",
+                error_type=PROVIDER_ERROR_TYPES["INIT_FAILED"],
+                message=f"Failed to initialize provider: {str(e)}"
+            )
+    
+    def initialize_client(self) -> None:
+        """Initialize WatsonX client."""
+        try:
+            # Initialize main client
+            self.client = APIClient(
+                project_id=self._provider_config.project_id,
+                credentials=Credentials(
+                    api_key=self._provider_config.api_key,
+                    url=self._provider_config.api_url
+                )
+            )
+
+            # Initialize embeddings client if model specified
+            if self._provider_config.embedding_model:
+                self.embeddings_client = wx_Embeddings(
+                    model_id=self._provider_config.embedding_model,
+                    project_id=self._provider_config.project_id,
+                    credentials=Credentials(
+                        api_key=self._provider_config.api_key,
+                        url=self._provider_config.api_url
+                    ),
+                    params={
+                        EmbedParams.RETURN_OPTIONS: {"input_text": True}
+                    }
+                )
+
+        except Exception as e:
+            if "authentication" in str(e).lower():
+                raise LLMProviderError(
+                    provider="watsonx",
+                    error_type=PROVIDER_ERROR_TYPES["AUTH_FAILED"],
+                    message=f"Authentication failed: {str(e)}"
+                )
+            raise LLMProviderError(
+                provider="watsonx",
+                error_type=PROVIDER_ERROR_TYPES["INIT_FAILED"],
+                message=f"Failed to initialize client: {str(e)}"
+            )
+
+    def _get_model(self, model_id: Optional[str] = None) -> ModelInference:
         """Get cached or create new model instance."""
         try:
+            # Use provided model_id or default from config
+            model_id = model_id or self._provider_config.default_model_id
+            
             if model_id not in self._model_cache:
-                generate_params = {
-                    GenParams.MAX_NEW_TOKENS: settings.max_new_tokens,
-                    GenParams.MIN_NEW_TOKENS: settings.min_new_tokens,
-                    GenParams.TEMPERATURE: settings.temperature,
-                    GenParams.TOP_K: settings.top_k,
-                    GenParams.RANDOM_SEED: settings.random_seed,
-                }
-                
                 model = ModelInference(
-                    persistent_connection=True,
                     model_id=model_id,
-                    params=generate_params,
-                    project_id=settings.wx_project_id,
+                    project_id=self._provider_config.project_id,
                     credentials=Credentials(
-                        api_key=settings.wx_api_key,
-                        url=settings.wx_url
+                        api_key=self._provider_config.api_key,
+                        url=self._provider_config.api_url
                     )
                 )
                 model.set_api_client(api_client=self.client)
                 self._model_cache[model_id] = model
                 
             return self._model_cache[model_id]
+            
         except Exception as e:
-            raise LLMProviderError(f"Failed to initialize model: {str(e)}")
+            raise LLMProviderError(
+                provider="watsonx",
+                error_type=PROVIDER_ERROR_TYPES["MODEL_ERROR"],
+                message=f"Failed to initialize model: {str(e)}"
+            )
 
     def generate_text(
-    self,
-    prompt: Union[str, List[str]],
-    model_parameters: ModelParametersInput,
-    template: Optional[BasePromptTemplate] = None,
-    provider_config: Optional[ProviderConfig] = None
-) -> Union[str, List[str]]:
+        self,
+        prompt: Union[str, List[str]],
+        model_parameters: LLMParametersBase,
+        template: Optional[PromptTemplateBase] = None,
+        provider_config: Optional[ProviderConfig] = None
+    ) -> Union[str, List[str]]:
         """Generate text using the WatsonX model."""
         try:
             self._ensure_client()
-            logger.info(f"Generating text with prompt: {prompt[:100]}...")
-
-            # Use default config if none provided
-            if provider_config is None:
-                provider_config = ProviderConfig()
             
-            # Prepare the prompt using the template if provided
+            # Use runtime config or defaults from provider config
+            config = provider_config or ProviderConfig(
+                timeout=self._provider_config.timeout,
+                max_retries=self._provider_config.max_retries,
+                batch_size=self._provider_config.batch_size
+            )
+            
+            # Prepare prompt
             prompt = self._prepare_prompts(prompt, template)
             
-            # Get or create model instance
+            # Get model and set parameters
             model = self._get_model()
-            
-            # Update generation parameters
             model.params.update({
                 GenParams.MAX_NEW_TOKENS: model_parameters.max_new_tokens,
                 GenParams.TEMPERATURE: model_parameters.temperature,
@@ -128,11 +166,12 @@ class WatsonXProvider(LLMProvider):
                 GenParams.RANDOM_SEED: model_parameters.random_seed
             })
             
-            response = model.generate_text(prompt=prompt, concurrency_limit=provider_config.concurrency_limit)
-
-             # Log the response type and content
-            logger.info(f"Response type: {type(response)}")
-            logger.info(f"Response content: {response}")
+            # Generate with runtime settings
+            response = model.generate_text(
+                prompt=prompt,
+                timeout=config.timeout,
+                max_retries=config.max_retries
+            )
 
             # Handle batch responses
             if isinstance(prompt, list):
@@ -141,8 +180,11 @@ class WatsonXProvider(LLMProvider):
                 elif isinstance(response, list):
                     return [r.strip() if isinstance(r, str) else r['generated_text'].strip() for r in response]
                 else:
-                    logger.error(f"Unexpected response type: {type(response)}")
-                    raise ValueError(f"Unexpected response type: {type(response)}")
+                    raise LLMProviderError(
+                        provider="watsonx",
+                        error_type=PROVIDER_ERROR_TYPES["RESPONSE_ERROR"],
+                        message=f"Unexpected batch response type: {type(response)}"
+                    )
             
             # Handle single response
             if isinstance(response, dict):
@@ -153,87 +195,109 @@ class WatsonXProvider(LLMProvider):
                 
             return response.strip() if isinstance(response, str) else response['generated_text'].strip()
             
+        except LLMProviderError:
+            raise
         except Exception as e:
-            logger.error(f"Text generation failed: {str(e)}")
-            raise LLMProviderError(f"Failed to generate text: {str(e)}")
+            raise LLMProviderError(
+                provider="watsonx",
+                error_type=PROVIDER_ERROR_TYPES["API_ERROR"],
+                message=f"Failed to generate text: {str(e)}"
+            )
 
     def generate_text_stream(
         self,
         prompt: str,
-        model_parameters: ModelParametersInput,
-        template: Optional[BasePromptTemplate] = None,
+        model_parameters: LLMParametersBase,
+        template: Optional[PromptTemplateBase] = None,
         provider_config: Optional[ProviderConfig] = None
     ) -> Generator[str, None, None]:
-        """Generate text in streaming mode.
-
-        Args:
-            prompt (str): Input text prompt.
-            model_parameters (ModelParametersInput): Generation parameters from model config.
-            template (Optional[PromptTemplateInput]): Optional prompt template.
-            provider_config (Optional[ProviderConfig]): Optional provider-specific settings.
-
-        Yields:
-            Generator[str, None, None]: Generated text chunks.
-        """
+        """Generate text in streaming mode."""
         try:
             self._ensure_client()
-            logger.info(f"Streaming generation for prompt: {prompt[:100]}...")
             
-            # Prepare the prompt using the template if provided
+            # Use runtime config or defaults from provider config
+            config = provider_config or ProviderConfig(
+                timeout=self._provider_config.timeout,
+                max_retries=self._provider_config.max_retries,
+                batch_size=self._provider_config.batch_size
+            )
+            
+            # Prepare prompt
             prompt = self._prepare_prompts(prompt, template)
             
-            # Get or create model instance
+            # Get model and set parameters
             model = self._get_model()
-            
-            # Update generation parameters
             model.params.update({
                 GenParams.MAX_NEW_TOKENS: model_parameters.max_new_tokens,
                 GenParams.TEMPERATURE: model_parameters.temperature,
                 GenParams.RANDOM_SEED: model_parameters.random_seed
             })
             
-            # Use stream generation
-            stream = model.generate_text_stream(prompt=prompt)
+            # Stream generation with runtime settings
+            stream = model.generate_text_stream(
+                prompt=prompt,
+                timeout=config.timeout,
+                max_retries=config.max_retries
+            )
             for chunk in stream:
                 if chunk and chunk.strip():
                     yield chunk.strip()
                     
+        except LLMProviderError:
+            raise
         except Exception as e:
-            logger.error(f"Streaming generation failed: {str(e)}")
-            raise LLMProviderError(f"Failed to generate streaming text: {str(e)}")
+            raise LLMProviderError(
+                provider="watsonx",
+                error_type=PROVIDER_ERROR_TYPES["API_ERROR"],
+                message=f"Failed to generate streaming text: {str(e)}"
+            )
 
     async def get_embeddings(
         self,
         texts: Union[str, List[str]],
         provider_config: Optional[ProviderConfig] = None
     ) -> EmbeddingsList:
-        """Generate embeddings for provided texts.
-
-        Args:
-            texts (Union[str, List[str]]): Text or list of texts to embed.
-            provider_config (Optional[ProviderConfig]): Optional provider-specific settings.
-
-        Returns:
-            EmbeddingsList: List of embedding vectors.
-        """
+        """Generate embeddings for texts."""
         try:
             self._ensure_client()
+            
+            # Check embeddings support
+            if not self.embeddings_client:
+                raise LLMProviderError(
+                    provider="watsonx",
+                    error_type=PROVIDER_ERROR_TYPES["CONFIG_INVALID"],
+                    message="Embeddings not configured - no embedding model specified"
+                )
+            
+            # Use runtime config or defaults from provider config
+            config = provider_config or ProviderConfig(
+                timeout=self._provider_config.timeout,
+                max_retries=self._provider_config.max_retries,
+                batch_size=self._provider_config.batch_size
+            )
+            
+            # Convert to list
             if isinstance(texts, str):
                 texts = [texts]
             
-            # Use provided client or get default
-            embeddings_client = self.embeddings_client or self._get_embeddings_client()
-            
-            # Generate embeddings using ThreadPoolExecutor
+            # Generate embeddings with runtime settings
             embedding_vectors = await asyncio.to_thread(
-                embeddings_client.embed_documents,
-                texts=texts
+                self.embeddings_client.embed_documents,
+                texts=texts,
+                timeout=config.timeout,
+                max_retries=config.max_retries
             )
             
             return embedding_vectors
+            
+        except LLMProviderError:
+            raise
         except Exception as e:
-            logger.error(f"Embedding generation failed: {str(e)}")
-            raise LLMProviderError(f"Failed to generate embeddings: {str(e)}")
+            raise LLMProviderError(
+                provider="watsonx",
+                error_type=PROVIDER_ERROR_TYPES["API_ERROR"],
+                message=f"Failed to generate embeddings: {str(e)}"
+            )
 
     def close(self) -> None:
         """Clean up provider resources."""
@@ -246,6 +310,5 @@ class WatsonXProvider(LLMProvider):
             self.embeddings_client = None
             self.client = None
             
-            logger.info("Successfully closed WatsonX provider connections")
         except Exception as e:
             logger.error(f"Error closing WatsonX provider: {str(e)}")

--- a/backend/rag_solution/schemas/provider_config_schema.py
+++ b/backend/rag_solution/schemas/provider_config_schema.py
@@ -1,12 +1,20 @@
 """Pydantic schemas for provider configuration."""
 
-from typing import Optional
+from typing import Optional, List
 from datetime import datetime
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, Field, ConfigDict, field_validator
 
 class ProviderModelConfigBase(BaseModel):
-    """Base schema for provider model configuration."""
+    """Base schema for provider model configuration.
     
+    Core configuration for LLM providers including:
+    - Model identification
+    - Provider credentials
+    - Model settings
+    - Runtime settings
+    """
+    
+    # Model identification
     model_id: str = Field(
         ...,
         description="Unique identifier for the model",
@@ -19,17 +27,57 @@ class ProviderModelConfigBase(BaseModel):
         min_length=1,
         max_length=255
     )
+    
+    # Provider credentials
+    api_key: str = Field(..., description="API key for provider authentication")
+    api_url: Optional[str] = Field(None, description="API endpoint URL")
+    project_id: Optional[str] = Field(None, description="Project ID")
+    org_id: Optional[str] = Field(None, description="Organization ID")
+    
+    # Model settings
+    default_model_id: str = Field(..., description="Default model ID for text generation")
+    embedding_model: Optional[str] = Field(None, description="Model ID for embeddings")
+    parameters_id: int = Field(..., description="ID of the associated LLM parameters")
+    
+    # Runtime settings
+    timeout: int = Field(default=30, description="Request timeout in seconds")
+    max_retries: int = Field(default=3, description="Maximum number of retry attempts")
+    batch_size: int = Field(default=10, description="Batch size for bulk operations")
+    
+    # Status
     is_active: bool = Field(
         True,
         description="Whether this model configuration is active"
     )
-    parameters_id: int = Field(
-        ...,
-        description="ID of the associated LLM parameters"
+
+    model_config = ConfigDict(
+        extra='allow',  # Allow extra fields for extensibility
+        from_attributes=True
     )
 
+    @field_validator('provider_name')
+    @classmethod
+    def validate_provider_name(cls, v: str) -> str:
+        """Ensure provider name is lowercase and contains only valid characters."""
+        v = v.lower()
+        if not v.isalnum() and not v.replace('_', '').isalnum():
+            raise ValueError("Provider name must contain only letters, numbers, and underscores")
+        return v
+
+    @field_validator('timeout', 'max_retries', 'batch_size')
+    @classmethod
+    def validate_positive(cls, v: int, field: str) -> int:
+        """Validate integer fields are positive."""
+        if v <= 0:
+            raise ValueError(f"{field} must be positive")
+        return v
+
 class ProviderModelConfigCreate(ProviderModelConfigBase):
-    """Schema for creating a new provider model configuration."""
+    """Schema for creating a new provider model configuration.
+    
+    This inherits directly from the base as all fields are required
+    for creation, with the same validation rules.
+    """
     pass
 
 class ProviderModelConfigUpdate(BaseModel):
@@ -47,14 +95,17 @@ class ProviderModelConfigUpdate(BaseModel):
         min_length=1,
         max_length=255
     )
-    is_active: Optional[bool] = Field(
-        None,
-        description="Whether this model configuration is active"
-    )
-    parameters_id: Optional[int] = Field(
-        None,
-        description="ID of the associated LLM parameters"
-    )
+    api_key: Optional[str] = Field(None, description="API key for provider authentication")
+    api_url: Optional[str] = Field(None, description="API endpoint URL")
+    project_id: Optional[str] = Field(None, description="Project ID")
+    org_id: Optional[str] = Field(None, description="Organization ID")
+    default_model_id: Optional[str] = Field(None, description="Default model ID for text generation")
+    embedding_model: Optional[str] = Field(None, description="Model ID for embeddings")
+    parameters_id: Optional[int] = Field(None, description="ID of the associated LLM parameters")
+    timeout: Optional[int] = Field(None, description="Request timeout in seconds")
+    max_retries: Optional[int] = Field(None, description="Maximum number of retry attempts")
+    batch_size: Optional[int] = Field(None, description="Batch size for bulk operations")
+    is_active: Optional[bool] = Field(None, description="Whether this model configuration is active")
 
 class ProviderModelConfigResponse(ProviderModelConfigBase):
     """Schema for provider model configuration responses."""
@@ -74,7 +125,7 @@ class ProviderRegistryResponse(BaseModel):
     
     total_providers: int = Field(..., description="Total number of registered providers")
     active_providers: int = Field(..., description="Number of active providers")
-    providers: list[ProviderModelConfigResponse] = Field(
+    providers: List[ProviderModelConfigResponse] = Field(
         ...,
         description="List of registered provider configurations"
     )

--- a/backend/tests/generation/test_provider_factory.py
+++ b/backend/tests/generation/test_provider_factory.py
@@ -1,0 +1,184 @@
+"""Tests for LLM provider factory."""
+
+import pytest
+from unittest.mock import Mock, patch
+from sqlalchemy.orm import Session
+
+from core.custom_exceptions import LLMProviderError
+from rag_solution.generation.providers.factory import LLMProviderFactory
+from rag_solution.generation.providers.base import LLMProvider
+from rag_solution.services.provider_config_service import ProviderConfigService
+from rag_solution.schemas.provider_config_schema import ProviderModelConfigBase
+
+@pytest.fixture
+def mock_provider():
+    """Mock provider class."""
+    class MockProvider(LLMProvider):
+        def __init__(self, provider_config_service: ProviderConfigService) -> None:
+            super().__init__()
+            self.provider_config_service = provider_config_service
+            self.client = Mock()
+            
+        def close(self) -> None:
+            self.client = None
+    return MockProvider
+
+@pytest.fixture
+def mock_config():
+    """Mock provider configuration."""
+    return ProviderModelConfigBase(
+        provider_name="mock",
+        model_id="mock-model",
+        default_model_id="mock-model",
+        api_key="mock-key",
+        parameters_id=1
+    )
+
+@pytest.fixture
+def provider_factory(db_session: Session):
+    """Factory fixture with mocked provider."""
+    factory = LLMProviderFactory(db_session)
+    return factory
+
+def test_get_provider(provider_factory: LLMProviderFactory, mock_provider, mock_config):
+    """Test getting a provider instance."""
+    # Add mock provider to registry
+    provider_factory._providers["mock"] = mock_provider
+    
+    # Mock config service
+    with patch.object(
+        provider_factory._provider_config_service,
+        'get_provider_config',
+        return_value=mock_config
+    ):
+        # Get provider instance
+        provider = provider_factory.get_provider("mock")
+        
+        # Verify instance
+        assert provider is not None
+        assert isinstance(provider, mock_provider)
+        assert provider.client is not None
+
+def test_get_unknown_provider(provider_factory: LLMProviderFactory):
+    """Test getting an unknown provider type."""
+    with pytest.raises(LLMProviderError) as exc_info:
+        provider_factory.get_provider("unknown")
+    assert exc_info.value.details["error_type"] == "unknown_provider"
+
+def test_provider_initialization_error(
+    provider_factory: LLMProviderFactory,
+    mock_provider
+):
+    """Test provider initialization error."""
+    # Mock provider that fails initialization
+    class FailingProvider(mock_provider):
+        def __init__(self, provider_config_service: ProviderConfigService) -> None:
+            super().__init__(provider_config_service)
+            self.client = None  # Simulate initialization failure
+    
+    # Add failing provider to registry
+    provider_factory._providers["failing"] = FailingProvider
+    
+    # Attempt to get provider
+    with pytest.raises(LLMProviderError) as exc_info:
+        provider_factory.get_provider("failing")
+    assert exc_info.value.details["error_type"] == "initialization_error"
+
+def test_provider_instance_caching(
+    provider_factory: LLMProviderFactory,
+    mock_provider,
+    mock_config
+):
+    """Test provider instance caching."""
+    # Add mock provider to registry
+    provider_factory._providers["mock"] = mock_provider
+    
+    # Mock config service
+    with patch.object(
+        provider_factory._provider_config_service,
+        'get_provider_config',
+        return_value=mock_config
+    ):
+        # Get provider instance twice
+        provider1 = provider_factory.get_provider("mock")
+        provider2 = provider_factory.get_provider("mock")
+        
+        # Verify same instance returned
+        assert provider1 is provider2
+
+def test_provider_reinitialization(
+    provider_factory: LLMProviderFactory,
+    mock_provider,
+    mock_config
+):
+    """Test provider reinitialization when client is None."""
+    # Add mock provider to registry
+    provider_factory._providers["mock"] = mock_provider
+    
+    # Mock config service
+    with patch.object(
+        provider_factory._provider_config_service,
+        'get_provider_config',
+        return_value=mock_config
+    ):
+        # Get initial instance
+        provider1 = provider_factory.get_provider("mock")
+        
+        # Simulate client failure
+        provider1.client = None
+        
+        # Get provider again
+        provider2 = provider_factory.get_provider("mock")
+        
+        # Verify new instance created
+        assert provider1 is not provider2
+        assert provider2.client is not None
+
+def test_provider_cleanup(
+    provider_factory: LLMProviderFactory,
+    mock_provider,
+    mock_config
+):
+    """Test provider cleanup."""
+    # Add mock provider to registry
+    provider_factory._providers["mock"] = mock_provider
+    
+    # Mock config service
+    with patch.object(
+        provider_factory._provider_config_service,
+        'get_provider_config',
+        return_value=mock_config
+    ):
+        # Get provider instance
+        provider = provider_factory.get_provider("mock")
+        assert provider.client is not None
+        
+        # Close all providers
+        provider_factory.close_all()
+        
+        # Verify cleanup
+        assert len(provider_factory._instances) == 0
+        assert provider.client is None
+
+def test_provider_case_insensitive(
+    provider_factory: LLMProviderFactory,
+    mock_provider,
+    mock_config
+):
+    """Test provider type is case insensitive."""
+    # Add mock provider to registry
+    provider_factory._providers["mock"] = mock_provider
+    
+    # Mock config service
+    with patch.object(
+        provider_factory._provider_config_service,
+        'get_provider_config',
+        return_value=mock_config
+    ):
+        # Get provider with different cases
+        provider1 = provider_factory.get_provider("MOCK")
+        provider2 = provider_factory.get_provider("mock")
+        provider3 = provider_factory.get_provider("Mock")
+        
+        # Verify same instance returned
+        assert provider1 is provider2 is provider3

--- a/backend/tests/test_provider_config.py
+++ b/backend/tests/test_provider_config.py
@@ -1,12 +1,13 @@
 """Tests for provider configuration management."""
 
 import pytest
-from datetime import datetime
+from unittest.mock import Mock, patch
 from sqlalchemy.orm import Session
 
-from core.custom_exceptions import ProviderConfigError
+from core.custom_exceptions import LLMProviderError, ProviderConfigError
 from rag_solution.models.provider_config import ProviderModelConfig
 from rag_solution.schemas.provider_config_schema import (
+    ProviderModelConfigBase,
     ProviderModelConfigCreate,
     ProviderModelConfigUpdate,
     ProviderModelConfigResponse
@@ -15,6 +16,8 @@ from rag_solution.repository.provider_config_repository import ProviderConfigRep
 from rag_solution.services.provider_config_service import ProviderConfigService
 from rag_solution.schemas.llm_parameters_schema import LLMParametersCreate
 from rag_solution.schemas.prompt_template_schema import PromptTemplateCreate
+from rag_solution.generation.providers.watsonx import WatsonXProvider
+from rag_solution.generation.providers.base import PROVIDER_ERROR_TYPES
 
 @pytest.fixture
 def provider_config_repo(db_session: Session) -> ProviderConfigRepository:
@@ -52,6 +55,22 @@ def sample_prompt_template() -> PromptTemplateCreate:
     )
 
 @pytest.fixture
+def sample_provider_base_config() -> ProviderModelConfigBase:
+    """Fixture for sample provider base configuration."""
+    return ProviderModelConfigBase(
+        provider_name="watsonx",
+        model_id="meta-llama/llama-3-1-8b-instruct",
+        default_model_id="meta-llama/llama-3-1-8b-instruct",
+        api_key="test-api-key",
+        api_url="https://test.watsonx.ai/api",
+        project_id="test-project",
+        parameters_id=1,
+        timeout=30,
+        max_retries=3,
+        batch_size=10
+    )
+
+@pytest.fixture
 def sample_provider_config(
     db_session: Session,
     sample_llm_params: LLMParametersCreate
@@ -67,7 +86,14 @@ def sample_provider_config(
     config = ProviderModelConfig(
         provider_name="watsonx",
         model_id="meta-llama/llama-3-1-8b-instruct",
+        default_model_id="meta-llama/llama-3-1-8b-instruct",
+        api_key="test-api-key",
+        api_url="https://test.watsonx.ai/api",
+        project_id="test-project",
         parameters_id=params.id,
+        timeout=30,
+        max_retries=3,
+        batch_size=10,
         is_active=True
     )
     db_session.add(config)
@@ -84,13 +110,34 @@ def test_create_provider_config(
     assert config is not None
     assert config.provider_name == "watsonx"
     assert config.model_id == "meta-llama/llama-3-1-8b-instruct"
+    assert config.default_model_id == "meta-llama/llama-3-1-8b-instruct"
+    assert config.api_key == "test-api-key"
+    assert config.api_url == "https://test.watsonx.ai/api"
+    assert config.project_id == "test-project"
+    assert config.timeout == 30
+    assert config.max_retries == 3
+    assert config.batch_size == 10
     assert config.is_active is True
 
-def test_get_provider_config(
+def test_get_provider_config_by_name(
+    provider_config_service: ProviderConfigService,
+    sample_provider_config: ProviderModelConfig
+):
+    """Test retrieving a provider configuration by name."""
+    config = provider_config_service.get_provider_config("watsonx")
+    assert config is not None
+    assert config.provider_name == "watsonx"
+    assert config.model_id == "meta-llama/llama-3-1-8b-instruct"
+    assert config.default_model_id == "meta-llama/llama-3-1-8b-instruct"
+    assert config.api_key == "test-api-key"
+    assert config.api_url == "https://test.watsonx.ai/api"
+    assert config.project_id == "test-project"
+
+def test_get_provider_config_by_model(
     provider_config_repo: ProviderConfigRepository,
     sample_provider_config: ProviderModelConfig
 ):
-    """Test retrieving a provider configuration."""
+    """Test retrieving a provider configuration by model."""
     config = provider_config_repo.get_by_provider_and_model(
         "watsonx",
         "meta-llama/llama-3-1-8b-instruct"
@@ -98,6 +145,7 @@ def test_get_provider_config(
     assert config is not None
     assert config.provider_name == "watsonx"
     assert config.model_id == "meta-llama/llama-3-1-8b-instruct"
+    assert config.default_model_id == "meta-llama/llama-3-1-8b-instruct"
 
 def test_list_provider_configs(
     provider_config_repo: ProviderConfigRepository,
@@ -114,10 +162,16 @@ def test_update_provider_config(
     sample_provider_config: ProviderModelConfig
 ):
     """Test updating a provider configuration."""
-    updates = ProviderModelConfigUpdate(is_active=False)
+    updates = ProviderModelConfigUpdate(
+        is_active=False,
+        timeout=60,
+        max_retries=5
+    )
     config = provider_config_repo.update(sample_provider_config.id, updates)
     assert config is not None
     assert config.is_active is False
+    assert config.timeout == 60
+    assert config.max_retries == 5
 
 def test_delete_provider_config(
     provider_config_repo: ProviderConfigRepository,
@@ -132,25 +186,35 @@ def test_delete_provider_config(
 def test_register_provider_model(
     provider_config_service: ProviderConfigService,
     sample_llm_params: LLMParametersCreate,
-    sample_prompt_template: PromptTemplateCreate
+    sample_prompt_template: PromptTemplateCreate,
+    sample_provider_base_config: ProviderModelConfigBase
 ):
     """Test registering a provider model through the service layer."""
     config = provider_config_service.register_provider_model(
         provider="watsonx",
         model_id="meta-llama/llama-3-1-8b-instruct",
         parameters=sample_llm_params,
+        provider_config=sample_provider_base_config,
         prompt_template=sample_prompt_template
     )
     assert config is not None
     assert config.provider_name == "watsonx"
     assert config.model_id == "meta-llama/llama-3-1-8b-instruct"
+    assert config.default_model_id == "meta-llama/llama-3-1-8b-instruct"
+    assert config.api_key == "test-api-key"
+    assert config.api_url == "https://test.watsonx.ai/api"
+    assert config.project_id == "test-project"
+    assert config.timeout == 30
+    assert config.max_retries == 3
+    assert config.batch_size == 10
     assert config.is_active is True
 
 def test_register_duplicate_provider_model(
     provider_config_service: ProviderConfigService,
     sample_provider_config: ProviderModelConfig,
     sample_llm_params: LLMParametersCreate,
-    sample_prompt_template: PromptTemplateCreate
+    sample_prompt_template: PromptTemplateCreate,
+    sample_provider_base_config: ProviderModelConfigBase
 ):
     """Test attempting to register a duplicate provider model."""
     with pytest.raises(ProviderConfigError) as exc_info:
@@ -158,9 +222,9 @@ def test_register_duplicate_provider_model(
             provider="watsonx",
             model_id="meta-llama/llama-3-1-8b-instruct",
             parameters=sample_llm_params,
+            provider_config=sample_provider_base_config,
             prompt_template=sample_prompt_template
         )
-    print(f"***** error: {exc_info.value.details['error_type']}")
     assert exc_info.value.details["error_type"] == "duplicate_error"
 
 def test_verify_provider_model(
@@ -187,6 +251,40 @@ def test_deactivate_provider_model(
     assert config is not None
     assert config.is_active is False
 
+def test_provider_validation(db_session: Session):
+    """Test provider-specific validation."""
+    # Create provider config service with empty database
+    provider_config_service = ProviderConfigService(db_session)
+    
+    # Test WatsonX provider with no config
+    with pytest.raises(LLMProviderError) as exc_info:
+        WatsonXProvider(provider_config_service)
+    assert exc_info.value.details["error_type"] == PROVIDER_ERROR_TYPES["CONFIG_INVALID"]
+
+def test_batch_size_validation():
+    """Test batch size validation."""
+    # Test invalid batch size
+    with pytest.raises(ValueError):
+        ProviderModelConfig(
+            provider_name="watsonx",
+            model_id="model",
+            default_model_id="model",
+            api_key="key",
+            parameters_id=1,
+            batch_size=0  # Invalid batch size
+        )
+    
+    # Test valid batch size
+    config = ProviderModelConfig(
+        provider_name="watsonx",
+        model_id="model",
+        default_model_id="model",
+        api_key="key",
+        parameters_id=1,
+        batch_size=5  # Valid batch size
+    )
+    assert config.batch_size == 5
+
 def test_model_validation():
     """Test provider model configuration validation."""
     # Test invalid model_id
@@ -194,6 +292,8 @@ def test_model_validation():
         ProviderModelConfig(
             provider_name="watsonx",
             model_id="",  # Empty model_id
+            default_model_id="model",
+            api_key="key",
             parameters_id=1
         )
     
@@ -202,7 +302,31 @@ def test_model_validation():
         ProviderModelConfig(
             provider_name="",  # Empty provider_name
             model_id="meta-llama/llama-3-1-8b-instruct",
+            default_model_id="model",
+            api_key="key",
             parameters_id=1
+        )
+    
+    # Test invalid timeout
+    with pytest.raises(ValueError):
+        ProviderModelConfig(
+            provider_name="watsonx",
+            model_id="model",
+            default_model_id="model",
+            api_key="key",
+            parameters_id=1,
+            timeout=0  # Invalid timeout
+        )
+    
+    # Test invalid max_retries
+    with pytest.raises(ValueError):
+        ProviderModelConfig(
+            provider_name="watsonx",
+            model_id="model",
+            default_model_id="model",
+            api_key="key",
+            parameters_id=1,
+            max_retries=-1  # Invalid max_retries
         )
 
 def test_schema_validation():
@@ -216,5 +340,28 @@ def test_schema_validation():
         ProviderModelConfigCreate(
             provider_name="",  # Empty provider_name
             model_id="meta-llama/llama-3-1-8b-instruct",
+            default_model_id="model",
+            api_key="key",
             parameters_id=1
+        )
+    
+    # Test provider name format
+    config = ProviderModelConfigCreate(
+        provider_name="WatsonX",  # Mixed case
+        model_id="model",
+        default_model_id="model",
+        api_key="key",
+        parameters_id=1
+    )
+    assert config.provider_name == "watsonx"  # Should be converted to lowercase
+    
+    # Test runtime settings validation
+    with pytest.raises(ValueError):
+        ProviderModelConfigCreate(
+            provider_name="watsonx",
+            model_id="model",
+            default_model_id="model",
+            api_key="key",
+            parameters_id=1,
+            timeout=-1  # Invalid timeout
         )


### PR DESCRIPTION
 This change moves provider configuration from direct settings to dedicated services.

1. Key changes:

- Update WatsonX, OpenAI, and Anthropic providers to use provider_config_service
- Add strong type checking with Pydantic models
- Implement consistent error handling across providers
- Add comprehensive tests for provider configuration
- Move credentials and endpoints to provider_config_service
- Use LLMParametersBase for model parameters
- Use PromptTemplateBase for prompt templates
- Update provider configuration documentation with:
- Accurate provider initialization examples
- Standardized error types
- Current factory implementation

2. Testing:

- Added provider validation tests
- Added configuration error handling tests
- Added provider lifecycle tests

3. Documentation:

- Updated provider configuration guide
- Added integration examples
- Added error handling guide
- Added best practices section