### PR TITLE
fix: Correct GHCR repository naming from rag-modulo to rag_modulo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ permissions:
 
 env:
   # Use GHCR images by default
-  BACKEND_IMAGE: ghcr.io/manavgup/rag-modulo/backend:latest
-  FRONTEND_IMAGE: ghcr.io/manavgup/rag-modulo/frontend:latest
-  TEST_IMAGE: ghcr.io/manavgup/rag-modulo/backend:latest
+  BACKEND_IMAGE: ghcr.io/manavgup/rag_modulo/backend:latest
+  FRONTEND_IMAGE: ghcr.io/manavgup/rag_modulo/frontend:latest
+  TEST_IMAGE: ghcr.io/manavgup/rag_modulo/backend:latest
 
 jobs:
   # Fast feedback - lint and unit tests without infrastructure  
@@ -123,8 +123,8 @@ jobs:
         id: build
         run: |
           # Build with commit SHA for uniqueness
-          BACKEND_TAG="ghcr.io/manavgup/rag-modulo/backend:${{ github.sha }}"
-          FRONTEND_TAG="ghcr.io/manavgup/rag-modulo/frontend:${{ github.sha }}"
+          BACKEND_TAG="ghcr.io/manavgup/rag_modulo/backend:${{ github.sha }}"
+          FRONTEND_TAG="ghcr.io/manavgup/rag_modulo/frontend:${{ github.sha }}"
           
           echo "Building backend image..."
           docker build -t $BACKEND_TAG -f ./backend/Dockerfile.backend ./backend
@@ -133,15 +133,15 @@ jobs:
           docker build -t $FRONTEND_TAG -f ./webui/Dockerfile.frontend ./webui
           
           # Also tag as latest for compose compatibility
-          docker tag $BACKEND_TAG ghcr.io/manavgup/rag-modulo/backend:latest
-          docker tag $FRONTEND_TAG ghcr.io/manavgup/rag-modulo/frontend:latest
+          docker tag $BACKEND_TAG ghcr.io/manavgup/rag_modulo/backend:latest
+          docker tag $FRONTEND_TAG ghcr.io/manavgup/rag_modulo/frontend:latest
           
           echo "Pushing images to GHCR..."
           # Push images to GHCR
           docker push $BACKEND_TAG
           docker push $FRONTEND_TAG
-          docker push ghcr.io/manavgup/rag-modulo/backend:latest
-          docker push ghcr.io/manavgup/rag-modulo/frontend:latest
+          docker push ghcr.io/manavgup/rag_modulo/backend:latest
+          docker push ghcr.io/manavgup/rag_modulo/frontend:latest
           
           echo "backend-image=$BACKEND_TAG" >> $GITHUB_OUTPUT
           echo "frontend-image=$FRONTEND_TAG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Fix 403 Forbidden errors when pushing to GitHub Container Registry (GHCR)
- Correct repository name mismatch from 'rag-modulo' (hyphen) to 'rag_modulo' (underscore)

## Problem
The CI workflow was failing with 403 Forbidden errors when trying to push images to GHCR because:
- Repository name: `rag_modulo` (with underscore)  
- GHCR image paths: `ghcr.io/manavgup/rag-modulo/` (with hyphen)

This naming inconsistency prevented successful image pushes to GitHub Container Registry.

## Changes
- Update environment variables (BACKEND_IMAGE, FRONTEND_IMAGE, TEST_IMAGE) 
- Update docker build and push commands to use correct repository name
- Ensure consistency between repository name and GHCR package paths

## Test Plan
- [x] Verify CI workflow file changes are correct
- [ ] Confirm CI pipeline runs without 403 errors
- [ ] Validate images are successfully pushed to GHCR