### PR TITLE
Remove continue-on-error from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,6 @@ jobs:
             ghcr.io/${{ github.repository }}/frontend:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-        continue-on-error: true
 
       - name: Build and push backend
         uses: docker/build-push-action@v5
@@ -50,4 +49,3 @@ jobs:
             ghcr.io/${{ github.repository }}/backend:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-        continue-on-error: true


### PR DESCRIPTION
Remove continue-on-error flags from Docker build steps to ensure proper failure handling and build quality gates.

🤖 Generated with [Claude Code](https://claude.ai/code)