### PR TITLE
Fix Codespaces .env file timing issue

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -115,7 +115,7 @@
     "IBM_CLIENT_SECRET": "${localEnv:IBM_CLIENT_SECRET}"
   },
   "shutdownAction": "stopCompose",
-  "onCreateCommand": "echo 'Codespace environment ready!'",
+  "onCreateCommand": "cp .env.example .env && echo 'Environment file created from template'",
   "updateContentCommand": "echo 'Updating Codespace environment...'",
-  "postCreateCommand": "mkdir -p /root/.vscode-server && chmod 755 /root/.vscode-server && apt-get update && apt-get install -y make curl && cd /workspaces/rag_modulo && cp .env.example .env && echo 'VS Code server directory created, make installed, and environment configured. Repository secrets provide RAG functionality. Edit .env to override with personal credentials.'"
+  "postCreateCommand": "mkdir -p /root/.vscode-server && chmod 755 /root/.vscode-server && apt-get update && apt-get install -y make curl && echo 'VS Code server directory created, make installed, and environment configured. Repository secrets provide RAG functionality. Edit .env to override with personal credentials.'"
 }


### PR DESCRIPTION
## 🚨 Problem

Codespaces creation fails because Docker Compose can't find the  file during configuration phase.

**Error:**
/var/lib/docker/codespacemount/workspace/rag_modulo/.env:  cannot open `/var/lib/docker/codespacemount/workspace/rag_modulo/.env' (No such file or directory)
not:                                                       cannot open `not' (No such file or directory)
found::                                                    cannot open `found:' (No such file or directory)
stat:                                                      cannot open `stat' (No such file or directory)
/var/lib/docker/codespacemount/workspace/rag_modulo/.env:: cannot open `/var/lib/docker/codespacemount/workspace/rag_modulo/.env:' (No such file or directory)
no:                                                        cannot open `no' (No such file or directory)
such:                                                      cannot open `such' (No such file or directory)
file:                                                      cannot open `file' (No such file or directory)
or:                                                        cannot open `or' (No such file or directory)
directory:                                                 cannot open `directory' (No such file or directory)

## 🎯 Root Cause

The  file creation was in , which runs **after** Docker Compose configuration. But Docker Compose needs the  file **during** the configuration phase.

## 🔧 Solution

Move  file creation from  to :

- **onCreateCommand**: Runs **before** Docker Compose configuration
- **postCreateCommand**: Runs **after** container creation

## 📋 Changes

- Move  to 
- Keep other setup commands in 
- Ensures  file exists when Docker Compose needs it

## 🧪 Testing

- [ ] Test Codespaces creation with new configuration
- [ ] Verify .env file is created before Docker Compose runs
- [ ] Confirm all services start successfully

Resolves Codespaces creation failure due to missing .env file timing.