### PR TITLE
feat: Add production deployment and improve local development

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,58 @@
+# Production docker-compose - Everything containerized
+version: '3.8'
+
+services:
+  # Extend infrastructure services
+  postgres:
+    extends:
+      file: docker-compose-infra.yml
+      service: postgres
+
+  milvus-standalone:
+    extends:
+      file: docker-compose-infra.yml
+      service: milvus-standalone
+
+  minio:
+    extends:
+      file: docker-compose-infra.yml
+      service: minio
+
+  mlflow-server:
+    extends:
+      file: docker-compose-infra.yml
+      service: mlflow-server
+
+  # Production backend
+  backend:
+    image: ${BACKEND_IMAGE:-ghcr.io/manavgup/rag_modulo/backend:latest}
+    container_name: rag-modulo-backend
+    env_file: .env
+    environment:
+      - MILVUS_HOST=milvus-standalone
+      - COLLECTIONDB_HOST=postgres
+    ports:
+      - "8000:8000"
+    depends_on:
+      - postgres
+      - milvus-standalone
+      - minio
+    networks:
+      - rag-network
+
+  # Production frontend
+  frontend:
+    image: ${FRONTEND_IMAGE:-ghcr.io/manavgup/rag_modulo/frontend:latest}
+    container_name: rag-modulo-frontend
+    environment:
+      - REACT_APP_BACKEND_URL=http://backend:8000
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+    networks:
+      - rag-network
+
+networks:
+  rag-network:
+    driver: bridge


### PR DESCRIPTION
## Summary

Adds production docker-compose configuration and improves local development workflow by enabling containerless development.

## Changes

### Production Deployment
- New docker-compose.production.yml file for full containerized deployment
  - Uses GHCR images by default (ghcr.io/manavgup/rag_modulo/backend:latest, frontend:latest)
  - Supports custom image override via BACKEND_IMAGE and FRONTEND_IMAGE env vars
  - Extends infrastructure services from docker-compose-infra.yml (DRY principle)
  - Proper networking with rag-network bridge
  - Environment variable configuration for container networking

### Local Development Improvement
- Updated frontend/package.json proxy configuration
  - Changed from http://backend:8000 to http://localhost:8000
  - Enables containerless development (npm run dev + poetry run uvicorn)
  - Faster iteration cycle without rebuilding containers
  - Required for local development workflow documented in Makefile

## Usage

### Production Deployment (All Containers)
```bash
make prod-start     # Start production environment
make prod-stop      # Stop production environment
make prod-logs      # View logs
make prod-status    # Check status
```

### Local Development (No Containers)
```bash
make local-dev-infra     # Start infrastructure only
make local-dev-backend   # Start backend locally with hot-reload
make local-dev-frontend  # Start frontend locally with HMR
```

## Benefits

**Production Deployment:**
- Production-like testing environment
- Uses same images as CI/CD pipeline
- Easy deployment to cloud providers
- Consistent with GitHub Container Registry workflow

**Local Development:**
- Instant hot-reload (no container rebuilds)
- Faster commits (pre-commit hooks work natively)
- Native debugging support
- Poetry and npm caches work locally

## Testing

- Tested production deployment with GHCR images
- Verified local development workflow with proxy change
- Confirmed services communicate correctly in both modes
- Validated make targets work as documented

Signed-off-by: Manav Gupta <manavg@gmail.com>