### PR TITLE
fix: Resolve PID file path resolution in local-dev-all target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,39 +120,40 @@ local-dev-frontend:
 
 local-dev-all:
 	@echo "$(CYAN)🚀 Starting full local development stack...$(NC)"
-	@mkdir -p .dev-pids logs
-	@$(MAKE) local-dev-infra
-	@echo "$(CYAN)🐍 Starting backend in background...$(NC)"
-	@cd backend && $(POETRY) run uvicorn main:app --reload --host 0.0.0.0 --port 8000 > ../logs/backend.log 2>&1 & echo $$! > ../.dev-pids/backend.pid
-	@sleep 2
-	@if [ -f .dev-pids/backend.pid ]; then \
-		if kill -0 $$(cat .dev-pids/backend.pid) 2>/dev/null; then \
-			echo "$(GREEN)✅ Backend started (PID: $$(cat .dev-pids/backend.pid))$(NC)"; \
+	@PROJECT_ROOT=$$(pwd); \
+	mkdir -p $$PROJECT_ROOT/.dev-pids $$PROJECT_ROOT/logs; \
+	$(MAKE) local-dev-infra; \
+	echo "$(CYAN)🐍 Starting backend in background...$(NC)"; \
+	cd backend && $(POETRY) run uvicorn main:app --reload --host 0.0.0.0 --port 8000 > $$PROJECT_ROOT/logs/backend.log 2>&1 & echo $$! > $$PROJECT_ROOT/.dev-pids/backend.pid; \
+	sleep 2; \
+	if [ -f $$PROJECT_ROOT/.dev-pids/backend.pid ]; then \
+		if kill -0 $$(cat $$PROJECT_ROOT/.dev-pids/backend.pid) 2>/dev/null; then \
+			echo "$(GREEN)✅ Backend started (PID: $$(cat $$PROJECT_ROOT/.dev-pids/backend.pid))$(NC)"; \
 		else \
 			echo "$(RED)❌ Backend failed to start - check logs/backend.log$(NC)"; \
 			exit 1; \
 		fi; \
-	fi
-	@echo "$(CYAN)⚛️  Starting frontend in background...$(NC)"
-	@cd frontend && npm run dev > ../logs/frontend.log 2>&1 & echo $$! > ../.dev-pids/frontend.pid
-	@sleep 2
-	@if [ -f .dev-pids/frontend.pid ]; then \
-		if kill -0 $$(cat .dev-pids/frontend.pid) 2>/dev/null; then \
-			echo "$(GREEN)✅ Frontend started (PID: $$(cat .dev-pids/frontend.pid))$(NC)"; \
+	fi; \
+	echo "$(CYAN)⚛️  Starting frontend in background...$(NC)"; \
+	cd frontend && npm run dev > $$PROJECT_ROOT/logs/frontend.log 2>&1 & echo $$! > $$PROJECT_ROOT/.dev-pids/frontend.pid; \
+	sleep 2; \
+	if [ -f $$PROJECT_ROOT/.dev-pids/frontend.pid ]; then \
+		if kill -0 $$(cat $$PROJECT_ROOT/.dev-pids/frontend.pid) 2>/dev/null; then \
+			echo "$(GREEN)✅ Frontend started (PID: $$(cat $$PROJECT_ROOT/.dev-pids/frontend.pid))$(NC)"; \
 		else \
 			echo "$(RED)❌ Frontend failed to start - check logs/frontend.log$(NC)"; \
 			exit 1; \
 		fi; \
-	fi
-	@echo "$(GREEN)✅ Local development environment running!$(NC)"
-	@echo "$(CYAN)💡 Services:$(NC)"
-	@echo "  Frontend:  http://localhost:3000"
-	@echo "  Backend:   http://localhost:8000"
-	@echo "  MLFlow:    http://localhost:5001"
-	@echo "$(CYAN)📋 Logs:$(NC)"
-	@echo "  Backend:   tail -f logs/backend.log"
-	@echo "  Frontend:  tail -f logs/frontend.log"
-	@echo "$(CYAN)🛑 Stop:$(NC) make local-dev-stop"
+	fi; \
+	echo "$(GREEN)✅ Local development environment running!$(NC)"; \
+	echo "$(CYAN)💡 Services:$(NC)"; \
+	echo "  Frontend:  http://localhost:3000"; \
+	echo "  Backend:   http://localhost:8000"; \
+	echo "  MLFlow:    http://localhost:5001"; \
+	echo "$(CYAN)📋 Logs:$(NC)"; \
+	echo "  Backend:   tail -f logs/backend.log"; \
+	echo "  Frontend:  tail -f logs/frontend.log"; \
+	echo "$(CYAN)🛑 Stop:$(NC) make local-dev-stop"
 
 local-dev-stop:
 	@echo "$(CYAN)🛑 Stopping local development services...$(NC)"


### PR DESCRIPTION
## Problem

After PR #360 merge, running `make local-dev-all` failed with:
```
/bin/sh: ../.dev-pids/backend.pid: No such file or directory
make: *** [local-dev-all] Error 1
```

## Root Cause

The `local-dev-all` target used relative paths (`../.dev-pids/`) after changing directories with `cd backend &&` and `cd frontend &&`. In the subshell context after the background operator `&`, these relative paths failed to resolve correctly, causing PID file writes to fail.

## Solution

1. **Capture absolute project root path** at target start: `PROJECT_ROOT=$(pwd)`
2. **Use absolute paths** for all PID and log files throughout the target
3. **Consolidate commands** into single shell execution with semicolons to ensure `PROJECT_ROOT` variable persists across all operations

## Changes

### Before (lines 121-156):
```makefile
local-dev-all:
	@echo "Starting..."
	@mkdir -p .dev-pids logs
	@cd backend && uvicorn ... > ../logs/backend.log 2>&1 & echo $$! > ../.dev-pids/backend.pid
	@cd frontend && npm run dev > ../logs/frontend.log 2>&1 & echo $$! > ../.dev-pids/frontend.pid
```

### After (lines 121-156):
```makefile
local-dev-all:
	@echo "Starting..."
	@PROJECT_ROOT=$$(pwd); \
	mkdir -p $$PROJECT_ROOT/.dev-pids $$PROJECT_ROOT/logs; \
	cd backend && uvicorn ... > $$PROJECT_ROOT/logs/backend.log 2>&1 & echo $$! > $$PROJECT_ROOT/.dev-pids/backend.pid; \
	cd frontend && npm run dev > $$PROJECT_ROOT/logs/frontend.log 2>&1 & echo $$! > $$PROJECT_ROOT/.dev-pids/frontend.pid
```

## Path Changes

| File Type | Before | After |
|-----------|--------|-------|
| Backend PID | `../.dev-pids/backend.pid` | `$$PROJECT_ROOT/.dev-pids/backend.pid` |
| Frontend PID | `../.dev-pids/frontend.pid` | `$$PROJECT_ROOT/.dev-pids/frontend.pid` |
| Backend log | `../logs/backend.log` | `$$PROJECT_ROOT/logs/backend.log` |
| Frontend log | `../logs/frontend.log` | `$$PROJECT_ROOT/logs/frontend.log` |

## Testing

- ✅ Verified absolute paths work regardless of working directory
- ✅ Ensured PID file checks reference same absolute paths
- ✅ Confirmed `make local-dev-stop` still works (uses relative paths from project root)

## Impact

**Fixes**: Post-PR #360 regression where `make local-dev-all` failed to start
**Affected**: Developers using local containerless development workflow
**Risk**: Low - only affects Makefile target, no code changes
**Compatibility**: Backwards compatible with existing workflows

## Related

- Regression from: PR #360 (Podcast UI improvements and auth fixes)
- Follows: Issue #348 (Streamlined Makefile)
- Affects: Local development workflow documented in `CLAUDE.md`

## Checklist

- [x] Tested `make local-dev-all` successfully starts services
- [x] Verified PID files created in correct location
- [x] Confirmed `make local-dev-stop` can stop services
- [x] Verified `make local-dev-status` reports correct status
- [x] No changes to production deployment targets
- [x] Pre-commit hooks pass