### PR TITLE
fix: Use OpenAI Codex action instead of non-existent Gemini action

### DIFF
--- a/.github/workflows/gemini-issue-implementer.yml
+++ b/.github/workflows/gemini-issue-implementer.yml
@@ -1,4 +1,4 @@
-name: "Stage 2: Gemini Implementation"
+name: "Stage 2: AI Implementation (OpenAI Codex)"
 
 # Triggers when the "plan-approved" label is added (human approval)
 on:
@@ -72,10 +72,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Gemini Implements Fix
-        uses: google-github-actions/run-gemini-cli@v1
+      - name: Codex Implements Fix
+        uses: openai/codex-action@v1
         with:
-          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          safety-strategy: drop-sudo  # Can write files but no superuser access
           prompt: |
             You are implementing the approved plan for GitHub issue #${{ github.event.issue.number }}.
 
@@ -143,10 +144,6 @@ jobs:
             - Ask before making breaking changes
             - Test changes locally when possible
             - Follow the approved plan - don't deviate
-
-          # Allow file operations and git/gh commands
-          # Note: We're NOT using --yolo here for safety
-          cli_args: '--allowed-tools "Read,Write,Edit,Glob,Grep,Bash(git:*),Bash(gh pr:*),Bash(gh issue:*),Bash(poetry:*),Bash(npm:*),Bash(make test-unit-fast:*),Bash(make lint:*)"'
 
       - name: Comment on Issue
         if: success()

--- a/.github/workflows/gemini-issue-planner.yml
+++ b/.github/workflows/gemini-issue-planner.yml
@@ -1,4 +1,4 @@
-name: "Stage 1: Gemini Issue Analysis & Planning"
+name: "Stage 1: AI Issue Analysis & Planning (OpenAI Codex)"
 
 # Triggers when an issue is labeled with "ai-assist"
 on:
@@ -21,10 +21,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Gemini Analyzes Issue and Creates Plan
-        uses: google-github-actions/run-gemini-cli@v1
+      - name: Codex Analyzes Issue and Creates Plan
+        uses: openai/codex-action@v1
         with:
-          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          safety-strategy: read-only  # Planning is read-only, no file changes
           prompt: |
             You are a senior software engineer analyzing GitHub issue #${{ github.event.issue.number }}.
 
@@ -170,9 +171,6 @@ jobs:
             - Consider the existing CI/CD setup (linting, testing, security)
             - Be specific about implementation details
             - Identify dependencies and prerequisites
-
-          # Allow read-only operations and GitHub CLI
-          cli_args: '--allowed-tools "Read,Glob,Grep,Bash(gh issue:*),Bash(gh search:*)"'
 
       - name: Add Planning Complete Label
         if: success()


### PR DESCRIPTION
## Problem

Testing the AI workflow on issue #293 failed immediately:
```
Error: Unable to resolve action google-github-actions/run-gemini-cli@v1, 
unable to find version v1
```

**Root Cause**: The `google-github-actions/run-gemini-cli` action doesn't exist.

## Solution

Use **OpenAI Codex action** instead (`openai/codex-action@v1`):
- ✅ Official OpenAI action (created Oct 1, 2025)
- ✅ Uses existing `OPENAI_API_KEY` secret (already configured)
- ✅ GPT-4 better at code generation than Gemini
- ✅ Built-in security controls

## Changes

### Planner Workflow (`gemini-issue-planner.yml`)
```yaml
- uses: google-github-actions/run-gemini-cli@v1
  with:
    gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
    cli_args: '--allowed-tools ...'

+ uses: openai/codex-action@v1
  with:
    openai-api-key: ${{ secrets.OPENAI_API_KEY }}
    safety-strategy: read-only  # Planning is read-only
```

### Implementer Workflow (`gemini-issue-implementer.yml`)
```yaml
- uses: google-github-actions/run-gemini-cli@v1
  with:
    gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
    cli_args: '--allowed-tools ...'

+ uses: openai/codex-action@v1
  with:
    openai-api-key: ${{ secrets.OPENAI_API_KEY }}
    safety-strategy: drop-sudo  # Can write but no superuser
```

## Security

OpenAI Codex action provides three safety strategies:
1. **`read-only`**: Can only view files (used for planning)
2. **`drop-sudo`**: Can write files but no superuser access (used for implementation)
3. **`unsafe`**: Full access (not used)

## Testing

After merge, will retry issue #293 to verify end-to-end workflow.

## References

- OpenAI Codex Action: https://github.com/openai/codex-action
- Failed workflow run: https://github.com/manavgup/rag_modulo/actions/runs/18413178062