### PR TITLE
fix: Add issue context to Codex planner prompt

### DIFF
--- a/.github/workflows/gemini-issue-planner.yml
+++ b/.github/workflows/gemini-issue-planner.yml
@@ -29,6 +29,17 @@ jobs:
           prompt: |
             You are a senior software engineer analyzing GitHub issue #${{ github.event.issue.number }}.
 
+            ## 📋 Issue Details
+
+            **Title:** ${{ github.event.issue.title }}
+
+            **Issue Body:**
+            ${{ github.event.issue.body }}
+
+            **Labels:** ${{ join(github.event.issue.labels.*.name, ', ') }}
+
+            ---
+
             ## 🛡️ STEP 1: COMPLEXITY ASSESSMENT (MANDATORY FIRST STEP)
 
             Before creating any implementation plan, you MUST assess complexity:


### PR DESCRIPTION
Fixes the Codex planning workflow to include issue details in the prompt.

## Problem

When testing the AI-assisted workflow on issue #293:
- ✅ Workflow ran successfully 
- ❌ Codex asked: "I don't have the text of GitHub issue #293 in this workspace"
- ❌ No plan was generated
- **Root cause**: `read-only` safety strategy prevents Codex from using `gh` commands

## Solution

Include issue details directly in the Codex prompt using GitHub Actions context:

```yaml
prompt: |
  You are a senior software engineer analyzing GitHub issue #${{ github.event.issue.number }}.
  
  ## 📋 Issue Details
  
  **Title:** ${{ github.event.issue.title }}
  
  **Issue Body:**
  ${{ github.event.issue.body }}
  
  **Labels:** ${{ join(github.event.issue.labels.*.name, ', ') }}
```

## Changes

- Added issue title, body, and labels to Codex prompt
- Uses built-in GitHub Actions context (`github.event.issue.*`)
- No changes to safety strategy or permissions needed

## Testing Plan

1. Merge this PR
2. Retry workflow on issue #293 by toggling `ai-assist` label
3. Verify Codex analyzes issue and posts plan
4. If plan approved, test full implementation workflow

## Expected Result

Codex will now:
1. ✅ Receive full issue context in prompt
2. ✅ Perform complexity assessment  
3. ✅ Generate implementation plan
4. ✅ Post plan as issue comment

## Related

- Follows up on PR #368 (OpenAI Codex action integration)
- Part of testing workflow on issue #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)