### PR TITLE
fix: Pass GH_TOKEN environment variable to Codex sandbox

### DIFF
--- a/.github/workflows/gemini-issue-planner.yml
+++ b/.github/workflows/gemini-issue-planner.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Codex Analyzes Issue and Creates Plan
         uses: openai/codex-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           safety-strategy: drop-sudo  # Can run gh commands but no file changes or sudo


### PR DESCRIPTION
Fixes the final piece of the AI workflow - allows Codex to post plans to issues.

## Problem

After PR #370 (drop-sudo safety strategy):
- ✅ Codex can run bash commands
- ✅ Codex analyzes issues and generates plans  
- ❌ **Plans not posted - GH_TOKEN unavailable in sandbox**

**Evidence from run #18419827098**:
```
Codex generated complete plan:
- Complexity: Simple (2 files, <100 LOC)
- Root Cause: apiClient doesn't map size_bytes from backend
- Files: apiClient.ts, LightweightCollectionDetail.tsx

Attempted: gh issue comment 293 --body "$(cat <<'EOF' ..."
Failed: "gh: To use GitHub CLI in a GitHub Actions workflow, 
set the GH_TOKEN environment variable"
```

## Root Cause

- Codex action runs in isolated sandbox
- Workflow has `GH_TOKEN` set in other steps
- **But Codex sandbox doesn't inherit environment variables**
- Must be explicitly passed via `env:` on the action step

## Solution

```yaml
- name: Codex Analyzes Issue and Creates Plan
  uses: openai/codex-action@v1
  env:                                    # ← NEW
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # ← NEW  
  with:
    openai-api-key: ${{ secrets.OPENAI_API_KEY }}
    safety-strategy: drop-sudo
```

## Testing Plan

1. Merge this PR
2. Retry workflow on issue #293:
   ```bash
   gh issue edit 293 --remove-label "ai-assist"
   gh issue edit 293 --add-label "ai-assist"
   ```
3. Verify Codex posts plan as comment
4. Review plan quality
5. If approved, add `plan-approved` to test implementation

## Expected Result

Codex will:
1. ✅ Receive issue context (PR #369)
2. ✅ Run bash commands (PR #370)
3. ✅ **Post plan to issue #293** ← THIS PR!

Then the full AI workflow will be operational!

## Related

- Builds on PR #369 (issue context in prompt)
- Builds on PR #370 (drop-sudo safety strategy)
- Completes AI-assisted workflow from PR #367/#368

🤖 Generated with [Claude Code](https://claude.com/claude-code)