### PR TITLE
fix: Pass GH_TOKEN to Codex implementer sandbox

### DIFF
--- a/.github/workflows/gemini-issue-implementer.yml
+++ b/.github/workflows/gemini-issue-implementer.yml
@@ -74,6 +74,8 @@ jobs:
 
       - name: Codex Implements Fix
         uses: openai/codex-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           safety-strategy: drop-sudo  # Can write files but no superuser access


### PR DESCRIPTION
Fixes the implementer workflow to access issue details.

## Problem

After adding `plan-approved` label to issue #293:
- ✅ Implementer workflow started
- ❌ Codex couldn't fetch issue details
- **Error**: "gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable"

**Evidence from run #18420200111**:
```
gh issue view 293 --json title,body
failed in sandbox: gh: To use GitHub CLI in a GitHub Actions workflow, 
set the GH_TOKEN environment variable
```

Codex posted comment asking for help instead of implementing.

## Root Cause

- Codex implementer step missing `env: GH_TOKEN`
- Same issue as planner (fixed in PR #371)
- Codex sandbox needs explicit environment variable passing

## Solution

```yaml
- name: Codex Implements Fix
  uses: openai/codex-action@v1
  env:                                    # ← NEW
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # ← NEW  
  with:
    openai-api-key: ${{ secrets.OPENAI_API_KEY }}
    safety-strategy: drop-sudo
```

Now Codex can:
- Fetch issue #293 details with `gh issue view`
- Read the approved plan from issue comments
- Implement the fix according to plan
- Create PR with implementation

## Testing Plan

1. Merge this PR
2. Remove `plan-approved` label from issue #293
3. Re-add `plan-approved` label to trigger workflow
4. Verify Codex implements fix and creates PR

## Related

- PR #371: Same fix for planner workflow
- Issue #293: Test case for AI workflow
- Completes infrastructure for AI-assisted development

🤖 Generated with [Claude Code](https://claude.com/claude-code)