### PR TITLE
fix: Include implementation plan in Codex prompt

### DIFF
--- a/.github/workflows/gemini-issue-implementer.yml
+++ b/.github/workflows/gemini-issue-implementer.yml
@@ -72,6 +72,25 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Fetch Implementation Plan
+        id: get_plan
+        run: |
+          # Fetch the latest AI Implementation Plan from issue comments
+          PLAN=$(gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments \
+            --jq '.[] | select(.body | contains("## 🤖 AI Implementation Plan")) | .body' | head -1)
+
+          if [ -z "$PLAN" ]; then
+            echo "❌ No implementation plan found in issue comments"
+            gh issue comment ${{ github.event.issue.number }} --body "❌ Implementation failed: No AI Implementation Plan found in issue comments. Please ensure the planning step completed successfully."
+            exit 1
+          fi
+
+          # Save plan to file (multiline safe)
+          echo "$PLAN" > /tmp/implementation_plan.md
+          echo "plan_file=/tmp/implementation_plan.md" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Codex Implements Fix
         uses: openai/codex-action@v1
         env:
@@ -82,8 +101,14 @@ jobs:
           prompt: |
             You are implementing the approved plan for GitHub issue #${{ github.event.issue.number }}.
 
+            ## 📋 Approved Implementation Plan
+
+            $(cat ${{ steps.get_plan.outputs.plan_file }})
+
+            ---
+
             **Your Task:**
-            1. Read the approved plan from the issue comments
+            1. Follow the approved plan above EXACTLY
             2. Create a new branch: `fix/issue-${{ github.event.issue.number }}`
             3. Implement the changes according to the plan
             4. Write/update tests as specified in the plan


### PR DESCRIPTION
Fixes Codex implementer to receive the plan directly in the prompt instead of fetching it via gh commands.

## Problem

After PR #373 (GH_TOKEN in env), workflow #18420370914 still failed:
```
gh issue view 293 --json title,body,comments
failed in sandbox: gh: To use GitHub CLI in a GitHub Actions workflow, 
set the GH_TOKEN environment variable
```

**Root Cause**: Setting `env: GH_TOKEN` on the action step doesn't propagate to Codex's `bash -lc` subshells. When Codex runs commands in its isolated sandbox, parent environment variables aren't inherited.

## Solution

**Fetch the plan BEFORE Codex and include it in the prompt** - just like we do for issue details in the planner workflow.

### New Step: "Fetch Implementation Plan"

```yaml
- name: Fetch Implementation Plan
  id: get_plan
  run: |
    # Fetch plan from issue comments via gh API (has GH_TOKEN access)
    PLAN=$(gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments \
      --jq '.[] | select(.body | contains("## 🤖 AI Implementation Plan")) | .body' | head -1)
    
    # Save to file and pass to Codex
    echo "$PLAN" > /tmp/implementation_plan.md
    echo "plan_file=/tmp/implementation_plan.md" >> $GITHUB_OUTPUT
```

### Updated Codex Prompt

```yaml
prompt: |
  ## 📋 Approved Implementation Plan
  
  $(cat ${{ steps.get_plan.outputs.plan_file }})
  
  ---
  
  **Your Task:**
  1. Follow the approved plan above EXACTLY
  2. Create branch and implement changes
  ...
```

## Why This Works

| Approach | Works? | Why |
|----------|--------|-----|
| `env: GH_TOKEN` on Codex step | ❌ No | Sandbox doesn't inherit parent env |
| Codex runs `gh` commands | ❌ No | No GH_TOKEN in bash subshells |
| **Fetch plan in workflow step, pass via prompt** | ✅ **Yes** | Regular workflow steps have GH_TOKEN access |

This mirrors how the planner workflow includes issue details directly in the prompt rather than having Codex fetch them.

## Testing Plan

1. Merge this PR
2. Remove and re-add `plan-approved` label on issue #293
3. Verify Codex receives plan in prompt
4. Verify Codex implements fix without needing gh commands
5. Verify PR is created successfully

## Related

- PR #373: Added GH_TOKEN (didn't fully solve the problem)
- PR #369: Planner includes issue details in prompt (same pattern)
- Issue #293: Test case for AI workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)