### PR TITLE
fix: Use printf for multi-line PLAN variable (critical bug in PR #375)

### DIFF
--- a/.github/workflows/gemini-issue-implementer.yml
+++ b/.github/workflows/gemini-issue-implementer.yml
@@ -91,7 +91,7 @@ jobs:
             echo ""
             echo "## 📋 Approved Implementation Plan"
             echo ""
-            echo "$PLAN"
+            printf '%s\n' "$PLAN"
             echo ""
             echo "---"
             echo ""


### PR DESCRIPTION
## Critical Bug Fix

PR #375 fixed the YAML syntax but introduced a subtle bug in how the multi-line  variable is output to the prompt file.

### The Bug

Line 94 of the workflow uses:
```bash
echo "$PLAN"
```

When  contains multi-line markdown content (which it does - it's the entire implementation plan comment),  doesn't properly handle it, resulting in the plan content being lost.

**Evidence:** In workflow run 18421284229, Codex received:
```
## 📋 Approved Implementation Plan

## 🤖 AI Implementation Plan

---

**Your Task:**
1. Follow the approved plan above EXACTLY
```

The plan content between the two headers is completely missing!

### The Fix

Replace  with \n

```bash
printf '%s\\n' "$PLAN"
```

 correctly handles multi-line strings and special characters, ensuring the full implementation plan is embedded in the Codex prompt.

### Testing

After merging, retry the workflow on issue #293:
```bash
gh issue edit 293 --remove-label "plan-approved"
gh issue edit 293 --add-label "plan-approved"
```

Expected result: Codex should receive the **complete implementation plan** with all details about:
- Root cause analysis
- Files to change
- Implementation approach
- Testing strategy

And actually implement the file size display fix instead of just exploring the codebase.

### Related

- Completes the fix from PR #375
- Enables automated AI implementation for issue #293
- Part of the larger AI-assisted development workflow