### PR TITLE
fix: Use direct_prompt parameter for Claude Code Action

### DIFF
--- a/.github/workflows/claude-issue-implementer.yml
+++ b/.github/workflows/claude-issue-implementer.yml
@@ -127,7 +127,8 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          prompt: ${{ steps.get_plan.outputs.prompt_content }}
+          direct_prompt: ${{ steps.get_plan.outputs.prompt_content }}
+          mode: direct
 
       - name: Add Success Label
         if: success()


### PR DESCRIPTION
## Problem

The Claude Code Action workflow (PR #377) was not executing because it used the wrong parameter name.

**Error from workflow logs:**
```
[warning]Unexpected input(s) 'prompt', valid inputs are [...]
No trigger was met for @claude
No trigger found, skipping remaining steps
```

## Root Cause

The workflow was using:
```yaml
with:
  prompt: ${{ steps.get_plan.outputs.prompt_content }}
```

But Claude Code Action expects one of:
- `direct_prompt` - For direct execution without trigger checking
- `override_prompt` - For overriding default prompts
- `custom_instructions` - For additional instructions

## Solution

Changed to:
```yaml
with:
  direct_prompt: ${{ steps.get_plan.outputs.prompt_content }}
  mode: direct
```

This tells Claude Code Action to:
1. Use `direct_prompt` parameter (correct name)
2. Run in `direct` mode (bypass trigger checking)
3. Execute immediately when workflow runs

## Testing

After merge, test with issue #293:
```bash
gh issue edit 293 --remove-label "plan-approved"
gh issue edit 293 --add-label "plan-approved"
```

Expected: Claude Code Action will execute the implementation plan and create a PR.

## References

- Original PR: #377
- Test issue: #293
- Claude Code Action docs: https://github.com/anthropics/claude-code-action