### PR TITLE
fix: Remove invalid 'mode: direct' parameter from Claude Code Action

### DIFF
--- a/.github/workflows/claude-issue-implementer.yml
+++ b/.github/workflows/claude-issue-implementer.yml
@@ -128,7 +128,6 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           direct_prompt: ${{ steps.get_plan.outputs.prompt_content }}
-          mode: direct
 
       - name: Add Success Label
         if: success()


### PR DESCRIPTION
## Problem

Testing revealed the Claude Code Action workflow failed with:
```
##[error]Prepare step failed with error: Invalid mode: direct
```

The `mode: direct` parameter is not valid.

## Root Cause

The Claude Code Action doesn't recognize `"direct"` as a valid mode value. The valid modes appear to be:
- `tag` (default) - Responds to @claude mentions
- Other trigger-based modes

## Solution

Remove the `mode: direct` parameter entirely. When using `direct_prompt`, the action should execute the prompt without needing a mode specification.

```yaml
# Before (fails)
with:
  direct_prompt: ${{ steps.get_plan.outputs.prompt_content }}
  mode: direct  # ❌ Invalid

# After (should work)
with:
  direct_prompt: ${{ steps.get_plan.outputs.prompt_content }}  # ✅
```

## Testing

After merge, re-test with issue #293:
```bash
gh issue edit 293 --remove-label "plan-approved"
gh issue edit 293 --add-label "plan-approved"
```

## References

- Previous PR: #379
- Failed workflow run: https://github.com/manavgup/rag_modulo/actions/runs/18431297674
- Test issue: #293