### PR TITLE
fix: Remove duplicate test run in pytest workflow

### DIFF
--- a/.github/workflows/04-pytest.yml
+++ b/.github/workflows/04-pytest.yml
@@ -74,19 +74,14 @@ jobs:
       - name: 📥 Install dependencies
         run: cd backend && poetry install --with dev,test
 
-      # 5️⃣ Run unit/atomic tests
-      - name: 🧪 Run unit tests
-        run: |
-          cd backend
-          poetry run pytest tests/ -m "unit or atomic" --tb=short -v --maxfail=5
-
-      # 6️⃣ Generate coverage report (optional)
-      - name: 📊 Run tests with coverage
-        if: success()
+      # 5️⃣ Run unit/atomic tests with coverage
+      - name: 🧪 Run unit tests with coverage
         run: |
           cd backend
           poetry run pytest tests/ -m "unit or atomic" \
             --cov=rag_solution \
             --cov-report=term-missing \
             --cov-report=html \
-            --tb=short
+            --tb=short \
+            -v \
+            --maxfail=5


### PR DESCRIPTION
## Summary

Fixes #384 

Removes duplicate test execution in `04-pytest.yml` workflow that was wasting CI/CD minutes.

## Problem

The workflow had two steps running **identical tests**:

### Before:
```yaml
# Step 5: Run tests WITHOUT coverage
- name: 🧪 Run unit tests
  run: poetry run pytest tests/ -m "unit or atomic" --tb=short -v --maxfail=5

# Step 6: Run tests WITH coverage (same tests!)
- name: 📊 Run tests with coverage
  if: success()
  run: poetry run pytest tests/ -m "unit or atomic" --cov=rag_solution ...
```

**Result**: Tests ran twice, doubling pytest job time from ~2-3 min to ~4-6 min per PR.

## Solution

### After:
```yaml
# Single step: Run tests WITH coverage
- name: 🧪 Run unit tests with coverage
  run: poetry run pytest tests/ -m "unit or atomic" \
    --cov=rag_solution \
    --cov-report=term-missing \
    --cov-report=html \
    --tb=short \
    -v \
    --maxfail=5
```

**Benefits**:
- ✅ ~50% faster pytest job (2-3 min instead of 4-6 min)
- ✅ Still get full test results AND coverage reports
- ✅ Coverage overhead is minimal (~5-10% slower than without)
- ✅ Simpler workflow, easier to maintain

## Why This Works

Coverage collection adds minimal overhead (~5-10%). Running tests twice provides no benefit:
- If tests pass without coverage → they'll pass with coverage
- If tests fail → we get failure immediately (coverage doesn't hide failures)
- We still get partial coverage on failures (helpful for debugging)

## Testing

This PR will demonstrate the time savings:
- Previous approach: ~4-6 min for pytest job
- New approach: ~2-3 min for pytest job
- Savings: ~2-3 min per PR (~50% faster)

## Impact

- Faster PR feedback for contributors
- Reduced GitHub Actions usage (saves ~100-150 minutes/month)
- No change in test coverage or quality
- No loss of functionality

## Related

Part of CI/CD optimization efforts (Issue #349)