### PR TITLE
[Issue #206] fix(nginx): resolve backend IP dynamically

### DIFF
--- a/frontend/default.conf
+++ b/frontend/default.conf
@@ -35,7 +35,12 @@ server {
 
     location /api/ {
         client_max_body_size 50M;
-        proxy_pass http://backend:8000;
+
+        # Dynamic resolver for Docker service discovery
+        resolver 127.0.0.11 valid=10s;
+        set $backend_host backend;
+        proxy_pass http://$backend_host:8000;
+
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
Fixes #206. This PR fixes a 502 Bad Gateway error that occurs when the backend container is restarted. The nginx configuration is updated to dynamically resolve the backend's IP address, preventing the use of a stale, cached IP.