### PR TITLE
refactor: Replace PID file tracking with HTTP health checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,9 @@ my_chroma_data/
 backend/logs/
 logs/
 
+# Development PID files (deprecated - no longer used)
+.dev-pids/
+
 # Project specific
 chroma/
 milvus.log


### PR DESCRIPTION
## Summary

Replaces unreliable PID file tracking with HTTP health checks for local development workflow. This fixes the false negative where `make local-dev-all` incorrectly reported backend startup failures when the backend was actually running successfully.

## Problem

The previous implementation used PID file tracking to verify service startup:
1. Start uvicorn with `--reload` flag
2. Write parent PID to `.dev-pids/backend.pid`
3. Check if process is alive using `kill -0 $PID`

**Issue**: `uvicorn --reload` spawns child processes for hot-reloading. The PID written to the file is the parent process that exits immediately, while the actual server runs under a different PID. This caused `kill -0` checks to fail even though the server was running.

## Solution

- **HTTP Health Checks**: Poll `/api/health` endpoint with curl to verify backend is responding
- **Remove .dev-pids/**: No longer needed, eliminating directory clutter
- **pkill for Cleanup**: Use `pkill -f "uvicorn main:app"` to stop processes by pattern matching
- **Status via HTTP**: `make local-dev-status` now uses HTTP checks to verify service health

## Changes

### Makefile
- `local-dev-all`: Uses 10-second timeout with curl health checks
- `local-dev-stop`: Uses pkill instead of PID files
- `local-dev-status`: Shows health status via HTTP checks
- `clean`: Removes `.dev-pids/` directory if present

### .gitignore
- Added `.dev-pids/` to ignore list (deprecated approach)

## Testing

```bash
# Test startup
make local-dev-all

# Verify status
make local-dev-status

# Stop services
make local-dev-stop
```

## Benefits

- ✅ No more false negatives on startup
- ✅ Simpler implementation without PID file management
- ✅ More reliable process detection with pkill
- ✅ Actual health verification via HTTP instead of process existence