### PR TITLE
fix: Add API key fallback for Claude Code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,7 +36,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # OAuth token preferred, API key as fallback
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Add support for ANTHROPIC_API_KEY as fallback authentication method in Claude Code review workflow to handle OAuth token expiration/revocation.

This fixes the CI failure where CLAUDE_CODE_OAUTH_TOKEN was missing or expired:
- OAuth token preferred (for Pro/Max users)
- API key as fallback (for API key users)
- Action will use whichever is available

Related: PR #452 CI failure
Issue: OAuth tokens expired in October 2025

🤖 Generated with [Claude Code](https://claude.com/claude-code)