### PR TITLE
fix: Fix type safety in provider update during initialization

### DIFF
--- a/backend/rag_solution/services/system_initialization_service.py
+++ b/backend/rag_solution/services/system_initialization_service.py
@@ -5,7 +5,7 @@ from core.config import Settings
 from core.custom_exceptions import LLMProviderError
 from core.logging_utils import get_logger
 from rag_solution.schemas.llm_model_schema import LLMModelInput, ModelType
-from rag_solution.schemas.llm_provider_schema import LLMProviderInput, LLMProviderOutput
+from rag_solution.schemas.llm_provider_schema import LLMProviderInput, LLMProviderOutput, LLMProviderUpdate
 from rag_solution.services.llm_model_service import LLMModelService
 from rag_solution.services.llm_provider_service import LLMProviderService
 
@@ -103,7 +103,7 @@ class SystemInitializationService:
             if existing_provider:
                 logger.info(f"Updating provider: {name}")
                 provider = self.llm_provider_service.update_provider(
-                    existing_provider.id, config.model_dump(exclude_unset=True)
+                    existing_provider.id, LLMProviderUpdate(**config.model_dump(exclude_unset=True))
                 )
                 if not provider:
                     raise LLMProviderError(name, "update", f"Failed to update {name}")


### PR DESCRIPTION
## Summary

Fixes critical startup failure caused by type mismatch when updating LLM providers during initialization. Backend was crashing with `AttributeError: 'dict' object has no attribute 'model_dump'`.

## Problem

Backend failed to start with error:
```
AttributeError: 'dict' object has no attribute 'model_dump'
```

**Root Cause:**
- `system_initialization_service.py` line 106 was passing a dict to `update_provider()`
- `llm_provider_repository.py` expected `LLMProviderUpdate` Pydantic model
- Type mismatch at service→repository boundary

**Before:**
```python
provider = self.llm_provider_service.update_provider(
    existing_provider.id, config.model_dump(exclude_unset=True)  # dict
)
```

## Solution

✅ Convert dict to Pydantic model before passing to repository
✅ Added `LLMProviderUpdate` import
✅ Enforces type safety at service→repository boundary

**After:**
```python
provider = self.llm_provider_service.update_provider(
    existing_provider.id, 
    LLMProviderUpdate(**config.model_dump(exclude_unset=True))  # Pydantic model
)
```

## Impact

- ✅ Backend starts successfully
- ✅ Provider initialization works correctly
- ✅ Type safety enforced
- ✅ Proper Pydantic validation on updates

## Files Changed

- `backend/rag_solution/services/system_initialization_service.py` (2 lines)

## Testing

- ✅ Backend starts without errors
- ✅ Provider initialization completes
- ✅ All providers loaded successfully

## Related

- Follows strict typing guidelines from `docs/development/backend/strict-typing-guidelines.md`
- Enforces Pydantic model usage at repository layer

## Type

- [x] Bug fix (critical - blocking startup)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)