### PR TITLE
fix: Remove arbitrary 10K char limit + fix datetime.utcnow() deprecation

### DIFF
--- a/backend/rag_solution/schemas/conversation_schema.py
+++ b/backend/rag_solution/schemas/conversation_schema.py
@@ -4,7 +4,7 @@ This module defines Pydantic schemas for conversation sessions, messages,
 context management, and question suggestions.
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 from uuid import uuid4
@@ -132,9 +132,9 @@ class ConversationSessionInput(BaseModel):
     ) -> "ConversationSessionOutput":
         """Convert input to output schema using Pydantic 2+ model validation."""
         if created_at is None:
-            created_at = datetime.utcnow()
+            created_at = datetime.now(UTC)
         if updated_at is None:
-            updated_at = datetime.utcnow()
+            updated_at = datetime.now(UTC)
 
         # Use model_dump() to get all input data, then update with additional fields
         data = self.model_dump()
@@ -163,8 +163,8 @@ class ConversationSessionOutput(BaseModel):
     max_messages: int = Field(..., description="Maximum number of messages")
     is_archived: bool = Field(default=False, description="Whether the session is archived")
     is_pinned: bool = Field(default=False, description="Whether the session is pinned")
-    created_at: datetime = Field(default_factory=datetime.utcnow, description="Creation timestamp")
-    updated_at: datetime = Field(default_factory=datetime.utcnow, description="Last update timestamp")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC), description="Creation timestamp")
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC), description="Last update timestamp")
     metadata: dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
     message_count: int = Field(default=0, description="Number of messages in the session")
 
@@ -234,7 +234,7 @@ class ConversationMessageInput(BaseModel):
     """Input schema for conversation messages."""
 
     session_id: UUID4 = Field(..., description="ID of the session")
-    content: str = Field(..., min_length=1, max_length=10000, description="Message content")
+    content: str = Field(..., min_length=1, max_length=100000, description="Message content")
     role: MessageRole = Field(..., description="Role of the message sender")
     message_type: MessageType = Field(..., description="Type of message")
     metadata: MessageMetadata | dict[str, Any] | None = Field(default=None, description="Message metadata")
@@ -246,7 +246,7 @@ class ConversationMessageInput(BaseModel):
     def to_output(self, message_id: UUID4, created_at: datetime | None = None) -> "ConversationMessageOutput":
         """Convert input to output schema using Pydantic 2+ model validation."""
         if created_at is None:
-            created_at = datetime.utcnow()
+            created_at = datetime.now(UTC)
 
         # Use model_dump() to get all input data, then update with additional fields
         data = self.model_dump()
@@ -263,7 +263,7 @@ class ConversationMessageOutput(BaseModel):
     content: str = Field(..., description="Message content")
     role: MessageRole = Field(..., description="Role of the message sender")
     message_type: MessageType = Field(..., description="Type of message")
-    created_at: datetime = Field(default_factory=datetime.utcnow, description="Creation timestamp")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC), description="Creation timestamp")
     metadata: MessageMetadata | None = Field(default=None, description="Message metadata")
     token_count: int | None = Field(default=None, description="Token count for this message")
     execution_time: float | None = Field(default=None, description="Execution time in seconds")
@@ -406,7 +406,7 @@ class ExportOutput(BaseModel):
     session_data: ConversationSessionOutput = Field(..., description="Session information")
     messages: list[ConversationMessageOutput] = Field(..., description="All messages in session")
     export_format: ExportFormat = Field(..., description="Format of the export")
-    export_timestamp: datetime = Field(default_factory=datetime.utcnow, description="Export timestamp")
+    export_timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC), description="Export timestamp")
     metadata: dict[str, Any] = Field(default_factory=dict, description="Export metadata")
 
 
@@ -463,7 +463,7 @@ class ConversationSummaryOutput(BaseModel):
     important_decisions: list[str] = Field(default_factory=list, description="Important decisions made")
     unresolved_questions: list[str] = Field(default_factory=list, description="Questions still unresolved")
     summary_strategy: SummarizationStrategy = Field(..., description="Strategy used for summarization")
-    created_at: datetime = Field(default_factory=datetime.utcnow, description="Summary creation timestamp")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC), description="Summary creation timestamp")
     metadata: dict[str, Any] = Field(default_factory=dict, description="Additional summary metadata")
 
     @classmethod
@@ -609,7 +609,7 @@ class ConversationExportOutput(BaseModel):
     messages: list[ConversationMessageOutput] = Field(..., description="Exported messages")
     summaries: list[ConversationSummaryOutput] = Field(default_factory=list, description="Conversation summaries")
     export_format: ExportFormat = Field(..., description="Format of the export")
-    export_timestamp: datetime = Field(default_factory=datetime.utcnow, description="Export timestamp")
+    export_timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC), description="Export timestamp")
     total_messages: int = Field(..., ge=0, description="Total number of messages exported")
     total_tokens: int = Field(default=0, ge=0, description="Total tokens in exported content")
     file_size_bytes: int = Field(default=0, ge=0, description="Size of exported file in bytes")

--- a/backend/rag_solution/services/conversation_service.py
+++ b/backend/rag_solution/services/conversation_service.py
@@ -6,7 +6,7 @@ and integration with search and context management services.
 
 import logging
 import re
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import UUID
 
@@ -570,7 +570,7 @@ class ConversationService:  # pylint: disable=too-many-instance-attributes,too-m
                 total_tokens=user_token_count + assistant_response_tokens,
                 model_name=model_name,
                 service_type=ServiceType.CONVERSATION,
-                timestamp=datetime.now(),
+                timestamp=datetime.now(UTC),
                 user_id=str(user_id),
             )
 
@@ -788,7 +788,7 @@ class ConversationService:  # pylint: disable=too-many-instance-attributes,too-m
             cot_usage_count=cot_usage_count,
             context_enhancement_count=context_enhancement_count,
             created_at=session.created_at,
-            last_activity=datetime.utcnow(),
+            last_activity=datetime.now(UTC),
             metadata={
                 "total_llm_calls": total_llm_calls,
                 "cot_token_count": cot_token_count,
@@ -811,7 +811,7 @@ class ConversationService:  # pylint: disable=too-many-instance-attributes,too-m
             "session_data": session,
             "messages": messages,
             "export_format": export_format,
-            "export_timestamp": datetime.utcnow(),
+            "export_timestamp": datetime.now(UTC),
             "metadata": {"cot_integration": True, "context_enhancement": True},
         }
 
@@ -1198,7 +1198,7 @@ class ConversationService:  # pylint: disable=too-many-instance-attributes,too-m
         """Clean up expired sessions and return count of cleaned sessions."""
 
         # Sessions expire after 7 days of inactivity
-        expiry_date = datetime.utcnow() - timedelta(days=7)
+        expiry_date = datetime.now(UTC) - timedelta(days=7)
 
         expired_sessions = (
             self.db.query(ConversationSession)
@@ -1382,7 +1382,7 @@ class ConversationService:  # pylint: disable=too-many-instance-attributes,too-m
             "topics": list(topics)[:10],  # Limit to top 10 topics
             "total_tokens": stats.total_tokens,
             "cot_usage_count": stats.cot_usage_count,
-            "generated_at": datetime.utcnow().isoformat(),
+            "generated_at": datetime.now(UTC).isoformat(),
         }
 
     def _generate_brief_summary(


### PR DESCRIPTION
## Problem

Users experiencing runtime errors when LLM responses exceed 10,000 characters:

```
ValidationError: 1 validation error for ConversationMessageInput
content
  String should have at most 10000 characters [type=string_too_long]
```

**Root Cause**: Arbitrary 10K character limit in `ConversationMessageInput.content` field

**Impact**: 
- Chain of Thought responses frequently exceed 10K chars
- Code examples and technical documentation can be lengthy
- Claude can output ~32,000 chars, GPT-4 ~16,000 chars
- Users getting 404 errors breaking conversation flow

## Changes

### 1. Message Content Length Fix

- **File**: `backend/rag_solution/schemas/conversation_schema.py`
- **Change**: Increased `max_length` from 10,000 → 100,000 characters
- **Rationale**: 
  - Accommodates all modern LLM outputs
  - Still provides reasonable upper bound for abuse prevention
  - Consistent with `context_window` limit (50,000 chars)

### 2. Python 3.12 Deprecation Fix

- **Files**: `conversation_schema.py`, `conversation_service.py`
- **Change**: Replaced `datetime.utcnow()` with `datetime.now(UTC)`
- **Occurrences**: 13 total (9 in schema, 4 in service)
- **Reason**: `datetime.utcnow()` deprecated in Python 3.12+
- **Migration**:
  - Direct calls: `datetime.utcnow()` → `datetime.now(UTC)`
  - Field defaults: `default_factory=datetime.utcnow` → `default_factory=lambda: datetime.now(UTC)`

## Testing

✅ Schema validation works with 50,000+ character content
✅ `datetime.now(UTC)` produces timezone-aware timestamps
✅ No breaking changes to API
✅ All imports valid

## Files Changed

- `backend/rag_solution/schemas/conversation_schema.py`
- `backend/rag_solution/services/conversation_service.py`

## Related

- Fixes: User-reported runtime error (conversation service validation failure)
- Related: Issue #520 (Python 3.12 deprecation warnings)