### PR TITLE
fix: Resolve critical blockers in Phase 3 Conversation Service Consolidation

### DIFF
--- a/backend/rag_solution/services/message_processing_orchestrator.py
+++ b/backend/rag_solution/services/message_processing_orchestrator.py
@@ -24,7 +24,8 @@ from rag_solution.schemas.conversation_schema import (
     MessageType,
 )
 from rag_solution.schemas.llm_usage_schema import LLMUsage, ServiceType
-from rag_solution.schemas.search_schema import SearchInput, SearchResult
+from rag_solution.schemas.search_schema import SearchInput
+from rag_solution.schemas.search_schema import SearchOutput as SearchResult
 from rag_solution.services.chain_of_thought_service import ChainOfThoughtService
 from rag_solution.services.conversation_context_service import ConversationContextService
 from rag_solution.services.llm_provider_service import LLMProviderService
@@ -217,13 +218,16 @@ class MessageProcessingOrchestrator:
         return search_result
 
     async def _serialize_response(
-        self, search_result: SearchResult, _user_token_count: int, user_id: UUID
+        self,
+        search_result: SearchResult,
+        user_token_count: int,  # noqa: ARG002
+        user_id: UUID,
     ) -> tuple[dict[str, Any], int]:
         """Serialize search result and calculate token usage.
 
         Args:
             search_result: Search result from SearchService
-            _user_token_count: User message token count (unused, reserved for future enhancements)
+            user_token_count: User message token count (unused, reserved for future enhancements)
             user_id: User ID
 
         Returns:

--- a/tests/unit/services/test_message_processing_orchestrator.py
+++ b/tests/unit/services/test_message_processing_orchestrator.py
@@ -202,7 +202,6 @@ def sample_search_result():
 class TestProcessUserMessage:
     """Test process_user_message method."""
 
-    @pytest.mark.skip(reason="Source code has parameter name mismatch: _serialize_response signature vs call site")
     @pytest.mark.asyncio
     async def test_process_user_message_successful_flow(
         self,
@@ -292,7 +291,6 @@ class TestProcessUserMessage:
         with pytest.raises(ValueError, match="Session not found"):
             await orchestrator.process_user_message(sample_message_input)
 
-    @pytest.mark.skip(reason="Source code has parameter name mismatch: _serialize_response signature vs call site")
     @pytest.mark.asyncio
     async def test_process_user_message_with_cot_reasoning(
         self,
@@ -374,7 +372,6 @@ class TestProcessUserMessage:
         assert result.cot_output is not None
         assert result.cot_output == cot_output
 
-    @pytest.mark.skip(reason="Source code has parameter name mismatch: _serialize_response signature vs call site")
     @pytest.mark.asyncio
     async def test_process_user_message_token_count_estimation(
         self,


### PR DESCRIPTION
## Summary
Fixes critical bugs introduced in PR #576 (Phase 3 Conversation Service Consolidation) that were identified in code review comment #3499270307.

## Changes
- Fix parameter name mismatch: `user_token_count` vs `_user_token_count` in `_serialize_response` method
- Fix import alias: `SearchOutput as SearchResult` from `search_schema`
- Un-skip 3 tests that were blocked by the parameter mismatch
- Add `noqa: ARG002` to suppress unused parameter warning (parameter reserved for future use)

## Test Results
All 19 tests in `test_message_processing_orchestrator.py` now passing (previously 16 passed, 3 skipped)

```bash
poetry run pytest tests/unit/services/test_message_processing_orchestrator.py -v
# Result: 19 passed, 3 warnings in 7.68s
```

## Related Issues
- Fixes critical blockers from PR #576 review comment #3499270307
- Addresses issues that caused 3 tests to be skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)