### PR TITLE
fix: Remove import for non-existent settings_router

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -40,7 +40,6 @@ from rag_solution.router.health_router import router as health_router
 from rag_solution.router.podcast_router import router as podcast_router
 from rag_solution.router.runtime_config_router import router as runtime_config_router
 from rag_solution.router.search_router import router as search_router
-from rag_solution.router.settings_router import router as settings_router
 from rag_solution.router.team_router import router as team_router
 from rag_solution.router.token_warning_router import router as token_warning_router
 from rag_solution.router.user_router import router as user_router
@@ -217,7 +216,6 @@ app.include_router(health_router)
 app.include_router(collection_router)
 app.include_router(podcast_router)
 app.include_router(runtime_config_router)
-app.include_router(settings_router)
 app.include_router(user_router)
 app.include_router(team_router)
 app.include_router(search_router)


### PR DESCRIPTION
## Summary
Fixes application startup error caused by importing a non-existent router module.

## Problem
`main.py` on the main branch imports `settings_router`, but this module only exists on the `feature/phase7-unified-conversation-service` branch. This causes the application to fail at startup with:

```
ModuleNotFoundError: No module named 'rag_solution.router.settings_router'
```

## Root Cause
The import was added in PR #555 (Dynamic Configuration System) but the corresponding router file (`backend/rag_solution/router/settings_router.py`) was never created on main. The file only exists on the Phase 7 WIP branch (commit c04aa32).

## Changes
- ✅ Remove `settings_router` import from `main.py` (line 43)
- ✅ Remove `settings_router` registration from app (line 219)

## Verification
```bash
cd backend && python -c "from main import app; print('✅ Import successful')"
# Result: ✅ Import successful
```

## Impact
- **Before**: Application fails to start
- **After**: Application starts successfully
- **Functionality**: No loss - `runtime_config_router` provides the runtime configuration functionality

## Related
- Import added in: PR #555 (commit a103dd6)
- Router file exists in: `feature/phase7-unified-conversation-service` (commit c04aa32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)