### PR TITLE
fix(docs): Add markdown attribute to HTML div tags for proper image rendering

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Welcome to RAG Modulo
 
-<div align="center">
+<div align="center" markdown="1">
 
 ![RAG Modulo Logo](https://via.placeholder.com/200x200/4F46E5/FFFFFF?text=RAG)
 
@@ -119,7 +119,7 @@ Get up and running with RAG Modulo in minutes:
 
 ## 📊 Current Status
 
-<div align="center">
+<div align="center" markdown="1">
 
 | Component | Status | Progress |
 |:---:|:---:|:---:|
@@ -348,7 +348,7 @@ This project is licensed under the **MIT License** - see the [LICENSE](https://g
 
 ---
 
-<div align="center">
+<div align="center" markdown="1">
 
 **Made with ❤️ by the RAG Modulo Team**
 


### PR DESCRIPTION

Fixes the issue where images and badges were showing as raw markdown syntax instead of being rendered. Added markdown="1" attribute to all <div> tags containing markdown content to enable proper rendering with MkDocs Material theme and the md_in_html extension.

Changes:
- Added markdown="1" to header div with logo and badges
- Added markdown="1" to status table div
- Added markdown="1" to footer div with social badges

This ensures all markdown content inside HTML blocks is properly parsed and rendered as HTML instead of being displayed as literal text.