### PR TITLE
hotfix: Fix community.kubernetes version to 2.0.1

### DIFF
--- a/deployment/ansible/requirements.yml
+++ b/deployment/ansible/requirements.yml
@@ -26,7 +26,7 @@ collections:
     version: "12.0.1"
 
   - name: community.kubernetes
-    version: "5.1.0"
+    version: "2.0.1"
 
   - name: kubernetes.core
     version: "6.2.0"


### PR DESCRIPTION
## Problem

The deployment workflow is failing with:
```
Error: Failed to resolve the requested dependencies map. Could not satisfy
the following requirements: * community.kubernetes:5.1.0 (direct request)
```

## Root Cause

Version `5.1.0` of `community.kubernetes` does not exist or is a pre-release.
The latest stable version is **2.0.1**.

## Solution

Changed:
```yaml
- name: community.kubernetes
  version: "5.1.0"  # ❌ Does not exist
```

To:
```yaml
- name: community.kubernetes
  version: "2.0.1"  # ✅ Latest stable
```

## Testing

- [x] YAML validation passes
- [ ] Will test in deployment workflow after merge

## Impact

**CRITICAL FIX** - Unblocks deployment workflow that has been failing since PR #634.

## Related

- Caused by PR #634 version pinning (my error in version research)
- Fixes deployment run: https://github.com/manavgup/rag_modulo/actions/runs/19345215727