### PR TITLE
fix: Add ca-tor region mapping for ICR

### DIFF
--- a/.github/workflows/deploy_complete_app.yml
+++ b/.github/workflows/deploy_complete_app.yml
@@ -84,9 +84,8 @@ env:
   FRONTEND_APP_NAME: ${{ vars.FRONTEND_APP_NAME || 'rag-modulo-frontend' }}
   IBM_CLOUD_REGION: ${{ vars.IBM_CLOUD_REGION || 'us-south' }}
   CR_NAMESPACE: ${{ vars.IBM_CR_NAMESPACE || 'rag_modulo' }}
-  # ICR uses shortened region names: us-south -> us, eu-gb -> uk, etc.
-  ICR_REGION: ${{ vars.IBM_CLOUD_REGION == 'eu-gb' && 'uk' || (vars.IBM_CLOUD_REGION == 'us-south' && 'us' ||
-    (vars.IBM_CLOUD_REGION == 'us-east' && 'us' || vars.IBM_CLOUD_REGION)) }}
+  # ICR uses shortened region names: us-south -> us, eu-gb -> uk, ca-tor -> ca, etc.
+  ICR_REGION: ${{ vars.IBM_CLOUD_REGION == 'eu-gb' && 'uk' || (vars.IBM_CLOUD_REGION == 'us-south' && 'us' || (vars.IBM_CLOUD_REGION == 'us-east' && 'us' || (vars.IBM_CLOUD_REGION == 'ca-tor' && 'ca' || vars.IBM_CLOUD_REGION))) }}
 
 # Prevent concurrent deployments to avoid conflicts
 concurrency:


### PR DESCRIPTION
- Added ca-tor -> ca mapping for Toronto region
- Fixes 'no such host' error for ca-tor.icr.io
- Toronto uses ca.icr.io as the registry endpoint