### PR TITLE
fix(workflow): Add SKIP_AUTH default value to prevent Pydantic validation errors

### DIFF
--- a/.github/workflows/deploy_complete_app.yml
+++ b/.github/workflows/deploy_complete_app.yml
@@ -85,7 +85,9 @@ env:
   IBM_CLOUD_REGION: ${{ vars.IBM_CLOUD_REGION || 'us-south' }}
   CR_NAMESPACE: ${{ vars.IBM_CR_NAMESPACE || 'rag_modulo' }}
   # ICR uses shortened region names: us-south -> us, eu-gb -> uk, ca-tor -> ca, etc.
-  ICR_REGION: ${{ vars.IBM_CLOUD_REGION == 'eu-gb' && 'uk' || (vars.IBM_CLOUD_REGION == 'us-south' && 'us' || (vars.IBM_CLOUD_REGION == 'us-east' && 'us' || (vars.IBM_CLOUD_REGION == 'ca-tor' && 'ca' || vars.IBM_CLOUD_REGION))) }}
+  ICR_REGION: ${{ vars.IBM_CLOUD_REGION == 'eu-gb' && 'uk' || (vars.IBM_CLOUD_REGION == 'us-south' && 'us' ||
+    (vars.IBM_CLOUD_REGION == 'us-east' && 'us' || (vars.IBM_CLOUD_REGION == 'ca-tor' && 'ca' ||
+    vars.IBM_CLOUD_REGION))) }}
 
 # Prevent concurrent deployments to avoid conflicts
 concurrency:
@@ -341,7 +343,7 @@ jobs:
           APP_NAME: ${{ env.BACKEND_APP_NAME }}
           IBM_CLOUD_REGION: ${{ env.IBM_CLOUD_REGION }}
           IBM_CLOUD_RESOURCE_GROUP: ${{ vars.IBM_CLOUD_RESOURCE_GROUP || 'rag-modulo-deployment' }}
-          SKIP_AUTH: ${{ secrets.SKIP_AUTH }}
+          SKIP_AUTH: ${{ secrets.SKIP_AUTH || 'false' }}
           OIDC_DISCOVERY_ENDPOINT: ${{ secrets.OIDC_DISCOVERY_ENDPOINT }}
           IBM_CLIENT_ID: ${{ secrets.IBM_CLIENT_ID }}
           IBM_CLIENT_SECRET: ${{ secrets.IBM_CLIENT_SECRET }}


### PR DESCRIPTION
## Summary

This PR fixes Pydantic validation errors that occur when the `SKIP_AUTH` secret is empty, which was causing backend deployment failures.

## Problem

When the `SKIP_AUTH` GitHub secret is not set or is empty, the backend receives an empty string `''`, causing this Pydantic validation error during Code Engine application startup:

```
Input should be a valid boolean, unable to interpret input
[type=bool_parsing, input_value='', input_type=str]
```

This error prevented the backend from starting and caused deployment failures.

## Solution

Added a default value `'false'` to the `SKIP_AUTH` environment variable in the deployment workflow:

**Before**:
```yaml
SKIP_AUTH: ${{ secrets.SKIP_AUTH }}
```

**After**:
```yaml
SKIP_AUTH: ${{ secrets.SKIP_AUTH || 'false' }}
```

Now when the secret is empty or unset, the backend receives `'false'` instead of `''`, which Pydantic can successfully parse as a boolean.

## Changes

- `.github/workflows/deploy_complete_app.yml` (line 346): Added default value to SKIP_AUTH

## Testing

This fix will be validated in the CI pipeline. Expected behavior:

✅ **If SKIP_AUTH secret is set**: Uses the configured value  
✅ **If SKIP_AUTH secret is empty/unset**: Defaults to `'false'`  
✅ **Backend starts successfully**: No Pydantic validation errors

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Deployment fix

## Related PRs

This is part of the focused PR strategy to replace PR #641:

- **PR #642**: Backend Docker fixes (transformers[vision] + numpy cleanup)
- **PR #643** (this PR): SKIP_AUTH default value fix
- **PR #644** (pending): Workflow Dockerfile path fix

## Checklist

- [x] Code follows the style guidelines of this project
- [x] Change is focused and addresses a single issue
- [x] Commit message follows conventional commits format
- [x] No breaking changes introduced
- [x] CI workflows will validate the change

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>