### PR TITLE
fix(prod): Fix production deployment configuration for make build-all and prod-start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -417,6 +417,9 @@ coverage: venv
 create-volumes:
 	@echo "$(CYAN)📁 Creating volume directories...$(NC)"
 	@mkdir -p ./volumes/postgres ./volumes/etcd ./volumes/minio ./volumes/milvus ./volumes/backend
+	# Note: chmod 777 is for LOCAL DEVELOPMENT ONLY to avoid permission issues
+	# For production deployments, use proper user/group mapping with Docker user namespaces
+	# or run containers with specific UIDs/GIDs that match your infrastructure
 	@find ./volumes -maxdepth 1 -type d -exec chmod 777 {} \; 2>/dev/null || true
 	@echo "$(GREEN)✅ Volumes created$(NC)"
 

--- a/backend/Dockerfile.backend
+++ b/backend/Dockerfile.backend
@@ -80,6 +80,12 @@ COPY backend/cli/ ./cli/
 COPY backend/vectordbs/ ./vectordbs/
 
 # Create a non-root user and group
+# /data directory: Used for file storage operations by the RAG system
+#   - Document uploads and processing
+#   - Temporary file storage during ingestion
+#   - File metadata and cached artifacts
+# chmod 777: Required for Settings validation to create storage_path at startup
+#   Note: For production, consider mounting a dedicated volume with proper permissions
 RUN groupadd --gid 10001 backend && \
     useradd --uid 10001 -g backend -M -d /nonexistent backend && \
     mkdir -p /app/logs /data && \

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -56,38 +56,61 @@ services:
     image: ${FRONTEND_IMAGE:-ghcr.io/manavgup/rag_modulo/frontend:latest}
     container_name: rag-modulo-frontend
     environment:
+      # BACKEND_URL: Used by nginx at runtime for proxy_pass in /api/ location
       - BACKEND_URL=http://backend:8000
+      # REACT_APP_BACKEND_URL: React build-time variable (already baked into image)
+      # Kept for consistency, but note: runtime changes have no effect on React bundle
+      - REACT_APP_BACKEND_URL=http://backend:8000
     ports:
       - "3000:8080"
     depends_on:
       - backend
     networks:
+      # Connected to both networks:
+      # - app-network: Communication with infrastructure (postgres, milvus, minio)
+      # - rag-network: Application-level network for frontend-backend communication
       - app-network
       - rag-network
 
 volumes:
+  # Using relative paths for better portability across environments
+  # Volumes are bind-mounted to ./volumes/ directory (created by make create-volumes)
   postgres_data:
     driver_opts:
       type: none
-      device: ${PWD}/volumes/postgres
+      device: ./volumes/postgres
       o: bind
   etcd_data:
     driver_opts:
       type: none
-      device: ${PWD}/volumes/etcd
+      device: ./volumes/etcd
       o: bind
   minio_data:
     driver_opts:
       type: none
-      device: ${PWD}/volumes/minio
+      device: ./volumes/minio
       o: bind
   milvus_data:
     driver_opts:
       type: none
-      device: ${PWD}/volumes/milvus
+      device: ./volumes/milvus
       o: bind
 
 networks:
+  # Network Architecture:
+  #
+  # app-network: Infrastructure network for services extended from docker-compose-infra.yml
+  #   - postgres, milvus-etcd, milvus-standalone, minio, mlflow-server
+  #   - These services maintain their original network configuration from infra file
+  #
+  # rag-network: Application network for RAG Modulo services
+  #   - backend, frontend
+  #
+  # Dual Network Membership (backend, frontend):
+  #   - Both backend and frontend connect to BOTH networks
+  #   - app-network: Required for backend to communicate with infrastructure (DB, vector store, storage)
+  #   - rag-network: Provides application-level isolation and frontend-backend communication
+  #   - This segmentation allows infrastructure services to be shared while keeping app services isolated
   rag-network:
     driver: bridge
   app-network:


### PR DESCRIPTION
## Summary

This PR fixes multiple critical issues preventing successful production deployment with `make build-all` and `make prod-start`.

## Issues Fixed

### 1. Frontend Build Failure ❌ → ✅
**Problem**: `make build-all` failed with "Dockerfile not found"
- Makefile referenced `frontend/Dockerfile` but file is `frontend/Dockerfile.frontend`
- Build context was `." but frontend source files are in `frontend/`

**Solution**:
- Updated Dockerfile path to `frontend/Dockerfile.frontend`
- Changed build context from `." to `frontend/`

### 2. Production Startup - Network Error ❌ → ✅
**Problem**: `make prod-start` failed with "undefined network app-network"
- Infrastructure services from `docker-compose-infra.yml` use `app-network`
- Production compose file only defined `rag-network`

**Solution**:
- Added both `app-network` and `rag-network` definitions
- Connected backend/frontend to both networks for proper communication
- Added missing infrastructure services (`milvus-etcd`, `createbuckets`)

### 3. Production Startup - Volume Error ❌ → ✅
**Problem**: Extended services referenced undefined volumes
- `postgres_data`, `etcd_data`, `minio_data`, `milvus_data` not defined

**Solution**:
- Added all volume definitions with bind mounts to `./volumes/*`

### 4. Volume Creation Error ❌ → ✅
**Problem**: Brace expansion created malformed directory `{postgres,etcd,minio,milvus,backend}`
- `chmod -R 777` caused permission errors on container-owned files

**Solution**:
- Explicit directory creation: `mkdir -p ./volumes/postgres ./volumes/etcd ...`
- Non-recursive chmod on top-level directories only

### 5. Backend Container Crash ❌ → ✅
**Problem**: Backend exited with "Permission denied: '/data'"
- Backend tried to create `/data` directory as non-root user

**Solution**:
- Create `/data` directory with proper ownership in Dockerfile before USER switch

### 6. Frontend Container Crash ❌ → ✅
**Problem**: Frontend exited with "unknown 'backend_url' variable"
- nginx expected `BACKEND_URL` but got `REACT_APP_BACKEND_URL`
- Port mapping was `3000:3000` but nginx listens on `8080`

**Solution**:
- Changed environment variable to `BACKEND_URL`
- Fixed port mapping to `3000:8080`

## Testing

### Build Testing
```bash
make build-all
```
✅ Backend image: `ghcr.io/manavgup/rag_modulo/backend:0.8.0`
✅ Frontend image: `ghcr.io/manavgup/rag_modulo/frontend:0.8.0`

### Production Deployment Testing
```bash
make prod-start
make prod-status
```

**All Services Running**:
- ✅ Frontend: http://localhost:3000
- ✅ Backend: http://localhost:8000
- ✅ MLFlow: http://localhost:5001
- ✅ Postgres: Port 5432 (healthy)
- ✅ Milvus: Port 19530 (healthy)
- ✅ MinIO: Port 9001 (healthy)

## Files Changed

- `Makefile` - Frontend build config and volume creation
- `docker-compose.production.yml` - Networks, volumes, environment variables
- `backend/Dockerfile.backend` - /data directory permissions

## Impact

- **Breaking**: None - These are fixes to already-broken production deployment
- **Migration**: None - Volume directories created automatically
- **Dependencies**: No dependency changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)