### PR TITLE
fix(config): Add missing generation_top_k setting to Settings class

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -151,6 +151,9 @@ class Settings(BaseSettings):
     keyword_weight: Annotated[float, Field(default=0.3, alias="KEYWORD_WEIGHT")]
     hybrid_weight: Annotated[float, Field(default=0.5, alias="HYBRID_WEIGHT")]
 
+    # Generation settings
+    generation_top_k: Annotated[int, Field(default=5, alias="GENERATION_TOP_K")]  # Number of sources to display
+
     # Reranking settings
     enable_reranking: Annotated[bool, Field(default=True, alias="ENABLE_RERANKING")]
     reranker_type: Annotated[str, Field(default="llm", alias="RERANKER_TYPE")]  # Options: llm, simple, cross-encoder


### PR DESCRIPTION
## Problem

The application was crashing with an `AttributeError` when processing conversation messages:

```
AttributeError: 'Settings' object has no attribute 'generation_top_k'
  at backend/rag_solution/services/message_processing_orchestrator.py:672
```

The `MessageProcessingOrchestrator._serialize_documents()` method was trying to access `self.settings.generation_top_k` to limit the number of sources displayed to the frontend, but this setting was missing from the Settings class.

## Solution

Added the missing `generation_top_k` field to the Settings class in `backend/core/config.py`:

- **Default value**: 5 (limits sources to 5 for frontend display)
- **Environment variable**: `GENERATION_TOP_K`
- **Purpose**: Controls the number of document sources returned to the frontend

## Changes

- `backend/core/config.py`: Added `generation_top_k` field with default value of 5

## Testing

After this fix:
- ✅ Conversation search requests no longer crash
- ✅ Sources are properly limited to the configured value (default 5)
- ✅ Can be customized via `GENERATION_TOP_K` environment variable

## Related

This was discovered during local testing of the conversation/search functionality.