### PR TITLE
fix(user): Add email-based user lookup to prevent duplicates (#719)

### DIFF
--- a/backend/rag_solution/repository/user_repository.py
+++ b/backend/rag_solution/repository/user_repository.py
@@ -81,6 +81,30 @@ class UserRepository:
             logger.error(f"Error getting user by IBM ID {ibm_id}: {e!s}")
             raise RepositoryError(f"Failed to get user by IBM ID: {e!s}") from e
 
+    def get_by_email(self, email: str) -> UserOutput:
+        """Fetches user by email address.
+
+        Args:
+            email: The email address to look up
+
+        Returns:
+            UserOutput: The user with the given email
+
+        Raises:
+            NotFoundError: If user not found
+            RepositoryError: For database errors
+        """
+        try:
+            user = self.db.query(User).filter(User.email == email).options(joinedload(User.teams)).first()
+            if not user:
+                raise NotFoundError("User", identifier=f"email={email}")
+            return UserOutput.model_validate(user)
+        except NotFoundError:
+            raise
+        except Exception as e:
+            logger.error(f"Error getting user by email {email}: {e!s}")
+            raise RepositoryError(f"Failed to get user by email: {e!s}") from e
+
     def update(self, user_id: UUID4, user_update: UserInput) -> UserOutput:
         """Updates user data with validation.
 


### PR DESCRIPTION
## Summary
- Added `get_by_email()` method to UserRepository for email-based user lookup
- Added `get_user_by_email()` and `get_or_create_by_email()` methods to UserService
- Updated MCP auth to use service layer instead of direct DB queries
- Changed exception handling to catch specific exceptions (`DomainError`, `RepositoryError`) instead of general `Exception`

## Problem
When using trusted proxy authentication with the `X-Authenticated-User` header, users were being looked up by `ibm_id` instead of email. This caused duplicate users when the existing user had a different `ibm_id` than their email address.

## Solution
The `get_or_create_by_email()` method now:
1. First looks up the user by email address
2. Only creates a new user if not found by email
3. Uses email as the `ibm_id` for new users created via trusted proxy

This prevents duplicate user creation while maintaining backward compatibility with existing users.

## Test plan
- [ ] Verify existing user lookup works by email
- [ ] Verify new user creation when no matching email exists
- [ ] Verify MCP authentication returns correct user data
- [ ] Verify no duplicate users are created during authentication

Fixes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)