### PR TITLE
SECURITY: Pin trivy-action to safe SHA - supply chain attack mitigation

### DIFF
--- a/.github/workflows/02-security.yml
+++ b/.github/workflows/02-security.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: 🔍 Scan Python dependencies (pyproject.toml, poetry.lock)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 pinned to SHA
         with:
           scan-type: "fs"
           scan-ref: "backend/"
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: 🔍 Scan Node dependencies (package.json, package-lock.json)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 pinned to SHA
         with:
           scan-type: "fs"
           scan-ref: "frontend/"

--- a/.github/workflows/03-build-secure.yml
+++ b/.github/workflows/03-build-secure.yml
@@ -170,7 +170,7 @@ jobs:
       - name: 🔎 Trivy - Vulnerability Scan
         id: trivy
         continue-on-error: true
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 pinned to SHA
         with:
           image-ref: ${{ matrix.image_name }}:${{ github.sha }}
           format: "sarif"
@@ -199,7 +199,7 @@ jobs:
       - name: 🔎 Trivy - Critical CVE Check
         id: trivy-critical
         continue-on-error: true
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 pinned to SHA
         with:
           image-ref: ${{ matrix.image_name }}:${{ github.sha }}
           format: "table"
@@ -270,7 +270,7 @@ jobs:
       - name: 🔍 Trivy - Filesystem Scan
         id: trivy-fs
         continue-on-error: true
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 pinned to SHA
         with:
           scan-type: "fs"
           scan-ref: ${{ matrix.context }}

--- a/.github/workflows/06-weekly-security-audit.yml
+++ b/.github/workflows/06-weekly-security-audit.yml
@@ -76,7 +76,7 @@ jobs:
           fi
 
       - name: 🔍 Trivy - Deep Vulnerability Scan (All Severities)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 pinned to SHA
         with:
           image-ref: "${{ matrix.image_name }}:audit"
           format: "sarif"
@@ -92,7 +92,7 @@ jobs:
           wait-for-processing: false
 
       - name: 🔍 Trivy - Generate Detailed Report
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 pinned to SHA
         with:
           image-ref: "${{ matrix.image_name }}:audit"
           format: "json"
@@ -117,7 +117,7 @@ jobs:
           docker run --rm -i hadolint/hadolint < ${{ matrix.dockerfile }} || true
 
       - name: 📦 Generate SBOM (Software Bill of Materials)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 pinned to SHA
         with:
           image-ref: "${{ matrix.image_name }}:audit"
           format: "cyclonedx"

--- a/.github/workflows/deploy_code_engine.yml
+++ b/.github/workflows/deploy_code_engine.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 pinned to SHA
         with:
           image-ref: ${{ env.IBM_CLOUD_REGION }}.icr.io/${{ env.CR_NAMESPACE }}/${{ env.APP_NAME }}:${{ github.sha }}
           format: "sarif"
@@ -76,7 +76,7 @@ jobs:
           sarif_file: "trivy-results.sarif"
 
       - name: Run Trivy vulnerability scanner (table format)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 pinned to SHA
         with:
           image-ref: ${{ env.IBM_CLOUD_REGION }}.icr.io/${{ env.CR_NAMESPACE }}/${{ env.APP_NAME }}:${{ github.sha }}
           format: "table"

--- a/.github/workflows/deploy_complete_app.yml
+++ b/.github/workflows/deploy_complete_app.yml
@@ -265,7 +265,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Run Trivy vulnerability scanner (Backend)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 pinned to SHA
         with:
           image-ref: ${{ env.ICR_REGION }}.icr.io/${{ env.CR_NAMESPACE }}/${{ env.BACKEND_APP_NAME }}:${{ github.sha }}
           format: "sarif"
@@ -278,7 +278,7 @@ jobs:
           sarif_file: "trivy-backend-results.sarif"
 
       - name: Run Trivy vulnerability scanner (Backend - Table)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 pinned to SHA
         with:
           image-ref: ${{ env.ICR_REGION }}.icr.io/${{ env.CR_NAMESPACE }}/${{ env.BACKEND_APP_NAME }}:${{ github.sha }}
           format: "table"
@@ -297,7 +297,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Run Trivy vulnerability scanner (Frontend)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 pinned to SHA
         with:
           image-ref: ${{ env.ICR_REGION }}.icr.io/${{ env.CR_NAMESPACE }}/${{ env.FRONTEND_APP_NAME }}:${{ github.sha }}
           format: "sarif"
@@ -310,7 +310,7 @@ jobs:
           sarif_file: "trivy-frontend-results.sarif"
 
       - name: Run Trivy vulnerability scanner (Frontend - Table)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 pinned to SHA
         with:
           image-ref: ${{ env.ICR_REGION }}.icr.io/${{ env.CR_NAMESPACE }}/${{ env.FRONTEND_APP_NAME }}:${{ github.sha }}
           format: "table"


### PR DESCRIPTION
## URGENT: Supply Chain Attack Mitigation

All 14 usages of `aquasecurity/trivy-action@master` across 5 workflow files have been pinned to the confirmed safe SHA:

```
aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
```

### Background

Trivy's GitHub Actions integration was compromised. Attackers force-pushed malicious commits to version tags and `master`, injecting a three-stage credential harvester that exfiltrates CI secrets (env vars, SSH keys, cloud credentials).

**Source**: https://thehackernews.com/2026/03/trivy-security-scanner-github-actions.html

### Changes

| Workflow | Refs Pinned |
|---|---|
| `02-security.yml` | 2 |
| `03-build-secure.yml` | 3 |
| `06-weekly-security-audit.yml` | 3 |
| `deploy_complete_app.yml` | 4 |
| `deploy_code_engine.yml` | 2 |
| **Total** | **14** |

### Additional Actions Required (manual)

- [ ] Review GitHub Actions audit logs for runs during the attack window
- [ ] Rotate CI/CD secrets (`GEMINI_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, Docker/GHCR creds)
- [ ] Check for IOC: repos named `tpcp-docs` in org
- [ ] Block exfiltration domain `scan.aquasecurtiy[.]org` / IP `45.148.10.212`

### Test plan

- [x] No `@master` refs remain in any workflow file
- [ ] CI passes (self-validating - workflows use the pinned SHA)

Closes #765